### PR TITLE
bugfix/10-distinction-of-supplier-added-directly-by-reporting-declarant-or-other-suppliers

### DIFF
--- a/cbam/cbam/doctype/supplier/supplier.json
+++ b/cbam/cbam/doctype/supplier/supplier.json
@@ -8,11 +8,11 @@
  "field_order": [
   "status",
   "column_break_xlzx",
-  "is_data_confirmed",
-  "column_break_muwl",
   "sub_supplier_level",
   "original_parent_supplier_number",
   "direct_parent_supplier",
+  "column_break_muwl",
+  "is_data_confirmed",
   "contact_details_section",
   "supplier_number",
   "supplier_name",
@@ -203,13 +203,13 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "Supplier Level 0 / Direct Supplier of Reporting Declarant",
    "fieldname": "original_parent_supplier_number",
    "fieldtype": "Data",
    "label": "Original Parent Supplier Number",
    "read_only": 1
   },
   {
-   "description": "If empty, the supplier is a direct supplier of the Reporting Declarant.",
    "fieldname": "direct_parent_supplier",
    "fieldtype": "Data",
    "label": "Direct Parent Supplier",
@@ -218,7 +218,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-24 16:23:52.764907",
+ "modified": "2024-09-25 10:00:56.738292",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Supplier",

--- a/cbam/cbam/doctype/supplier/supplier.json
+++ b/cbam/cbam/doctype/supplier/supplier.json
@@ -218,7 +218,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-25 10:00:56.738292",
+ "modified": "2024-09-25 13:09:40.776344",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Supplier",

--- a/cbam/cbam/doctype/supplier/supplier.py
+++ b/cbam/cbam/doctype/supplier/supplier.py
@@ -54,38 +54,42 @@ class Supplier(Document):
 			user_doc = frappe.get_doc("User", user)
 			# frappe.msgprint(f"User: {user}")
 
-			try:
-				user_supplier = frappe.db.get_value("Supplier Employee", {'email': user}, ['supplier_company'])
-				# frappe.msgprint(f"User Supplier: {user_supplier}")
-				user_supplier_number = frappe.db.get_value("Supplier", user_supplier, 'supplier_number')
-			except:
-				frappe.throw("Cannot find your supplier number. Please contact the system administrator.")
-			try:
-				original_parent_supplier_number = frappe.db.get_value("Supplier", user_supplier, 'original_parent_supplier_number')
-				# frappe.msgprint(f"Tired Original Parent Supplier Number: {original_parent_supplier_number}")
-			except:
-				original_parent_supplier_number = None
-			if not original_parent_supplier_number:
-				original_parent_supplier_number = user_supplier_number
-				# frappe.msgprint(f"After if not: Original Parent Supplier Number: {original_parent_supplier_number}")
-			try:
-				direct_parent_sub_supplier_level = frappe.db.get_value("Supplier", user_supplier, 'sub_supplier_level')
-				# frappe.msgprint(f"Direct Parent Sub Supplier Level: {direct_parent_sub_supplier_level}")
-			except:
-				direct_parent_sub_supplier_level = None
+			if user_doc.role_profiles:
+				user_role_profiles_list = [profile.role_profile for profile in user_doc.role_profiles]
+				#frappe.msgprint(f"User Role Profiles: {user_role_profiles_list}")
+				if "00 Supplier" in user_role_profiles_list:
+					try:
+						user_supplier = frappe.db.get_value("Supplier Employee", {'email': user}, ['supplier_company'])
+						# frappe.msgprint(f"User Supplier: {user_supplier}")
+						user_supplier_number = frappe.db.get_value("Supplier", user_supplier, 'supplier_number')
+					except:
+						frappe.throw("Cannot find your supplier number. Please contact the system administrator.")
+					try:
+						original_parent_supplier_number = frappe.db.get_value("Supplier", user_supplier, 'original_parent_supplier_number')
+						# frappe.msgprint(f"Tired Original Parent Supplier Number: {original_parent_supplier_number}")
+					except:
+						original_parent_supplier_number = None
+					if not original_parent_supplier_number:
+						original_parent_supplier_number = user_supplier_number
+						# frappe.msgprint(f"After if not: Original Parent Supplier Number: {original_parent_supplier_number}")
+					try:
+						direct_parent_sub_supplier_level = frappe.db.get_value("Supplier", user_supplier, 'sub_supplier_level')
+						# frappe.msgprint(f"Direct Parent Sub Supplier Level: {direct_parent_sub_supplier_level}")
+					except:
+						direct_parent_sub_supplier_level = None
 
-			if direct_parent_sub_supplier_level is None:
-				direct_parent_sub_supplier_level = 0
-				# frappe.msgprint(f"After if none: Direct Parent Sub Supplier Level: {direct_parent_sub_supplier_level}")
+					if direct_parent_sub_supplier_level is None:
+						direct_parent_sub_supplier_level = 0
+						# frappe.msgprint(f"After if none: Direct Parent Sub Supplier Level: {direct_parent_sub_supplier_level}")
 
-			self.sub_supplier_level = direct_parent_sub_supplier_level + 1
+					self.sub_supplier_level = direct_parent_sub_supplier_level + 1
 
-			self.original_parent_supplier_number = original_parent_supplier_number
-			# frappe.msgprint(f"Original Parent Supplier Number: {original_parent_supplier_number}")
-			self.direct_parent_supplier = user_supplier
-			# frappe.msgprint(f"Direct Parent Supplier: {user_supplier}")
-			self.supplier_number = f"{direct_parent_sub_supplier_level + 1}S-{original_parent_supplier_number}"
-			# frappe.msgprint(f"Supplier Number: {self.supplier_number}")
+					self.original_parent_supplier_number = original_parent_supplier_number
+					# frappe.msgprint(f"Original Parent Supplier Number: {original_parent_supplier_number}")
+					self.direct_parent_supplier = user_supplier
+					# frappe.msgprint(f"Direct Parent Supplier: {user_supplier}")
+					self.supplier_number = f"{direct_parent_sub_supplier_level + 1}S-{original_parent_supplier_number}"
+					# frappe.msgprint(f"Supplier Number: {self.supplier_number}")
 		except Exception as e:
 			# Log any errors encountered
 			frappe.log_error(message=str(e), title="Error processing supplier number")

--- a/cbam/cbam/doctype/supplier/supplier.py
+++ b/cbam/cbam/doctype/supplier/supplier.py
@@ -52,40 +52,40 @@ class Supplier(Document):
 		try:
 			user = frappe.session.user
 			user_doc = frappe.get_doc("User", user)
-			frappe.msgprint(f"User: {user}")
+			# frappe.msgprint(f"User: {user}")
 
 			try:
 				user_supplier = frappe.db.get_value("Supplier Employee", {'email': user}, ['supplier_company'])
-				frappe.msgprint(f"User Supplier: {user_supplier}")
+				# frappe.msgprint(f"User Supplier: {user_supplier}")
 				user_supplier_number = frappe.db.get_value("Supplier", user_supplier, 'supplier_number')
 			except:
 				frappe.throw("Cannot find your supplier number. Please contact the system administrator.")
 			try:
 				original_parent_supplier_number = frappe.db.get_value("Supplier", user_supplier, 'original_parent_supplier_number')
-				frappe.msgprint(f"Tired Original Parent Supplier Number: {original_parent_supplier_number}")
+				# frappe.msgprint(f"Tired Original Parent Supplier Number: {original_parent_supplier_number}")
 			except:
 				original_parent_supplier_number = None
 			if not original_parent_supplier_number:
 				original_parent_supplier_number = user_supplier_number
-				frappe.msgprint(f"After if not: Original Parent Supplier Number: {original_parent_supplier_number}")
+				# frappe.msgprint(f"After if not: Original Parent Supplier Number: {original_parent_supplier_number}")
 			try:
 				direct_parent_sub_supplier_level = frappe.db.get_value("Supplier", user_supplier, 'sub_supplier_level')
-				frappe.msgprint(f"Direct Parent Sub Supplier Level: {direct_parent_sub_supplier_level}")
+				# frappe.msgprint(f"Direct Parent Sub Supplier Level: {direct_parent_sub_supplier_level}")
 			except:
 				direct_parent_sub_supplier_level = None
 
 			if direct_parent_sub_supplier_level is None:
 				direct_parent_sub_supplier_level = 0
-				frappe.msgprint(f"After if none: Direct Parent Sub Supplier Level: {direct_parent_sub_supplier_level}")
+				# frappe.msgprint(f"After if none: Direct Parent Sub Supplier Level: {direct_parent_sub_supplier_level}")
 
 			self.sub_supplier_level = direct_parent_sub_supplier_level + 1
 
 			self.original_parent_supplier_number = original_parent_supplier_number
-			frappe.msgprint(f"Original Parent Supplier Number: {original_parent_supplier_number}")
+			# frappe.msgprint(f"Original Parent Supplier Number: {original_parent_supplier_number}")
 			self.direct_parent_supplier = user_supplier
-			frappe.msgprint(f"Direct Parent Supplier: {user_supplier}")
+			# frappe.msgprint(f"Direct Parent Supplier: {user_supplier}")
 			self.supplier_number = f"{direct_parent_sub_supplier_level + 1}S-{original_parent_supplier_number}"
-			frappe.msgprint(f"Supplier Number: {self.supplier_number}")
+			# frappe.msgprint(f"Supplier Number: {self.supplier_number}")
 		except Exception as e:
 			# Log any errors encountered
 			frappe.log_error(message=str(e), title="Error processing supplier number")


### PR DESCRIPTION
#### New Fields
![image](https://github.com/user-attachments/assets/a6208836-6c79-4de9-ae6c-e647cb35185b)


#### How it works
When a Supplier Employee adds another Supplier Company (a Sub-Supplier) through the Web Form, the code counts +1 to the Sub Supplier Level and fills the other two fild (original_parent_supplier_number and direct_parent_supplier) accordingly. Additionally, the supplier number gets the level + S + original_parent_supplier_number.
