### PR TITLE
feature/57-Add-emissions-request-web-form-and-logics

### DIFF
--- a/cbam/cbam/doctype/customs_import/customs_import.js
+++ b/cbam/cbam/doctype/customs_import/customs_import.js
@@ -9,9 +9,9 @@
 
 frappe.ui.form.on("Customs Import", {
 	refresh(frm) {
-		frm.add_custom_button(__("Sent all Emails (yet not sent)"), function () {
+		frm.add_custom_button(__("Send all Emails (not yet sent)"), function () {
 			frappe.call({
-				method: "cbam.send_email_from_customs_import.create_user_and_send_email", // OPEN
+				method: "cbam.send_email_from_customs_import.create_user_and_send_email",
 				args: {
 					goods_list: cur_frm.doc.goods,
 				},

--- a/cbam/cbam/doctype/good/good.js
+++ b/cbam/cbam/doctype/good/good.js
@@ -27,7 +27,7 @@ frappe.ui.form.on('Good', {
 
 frappe.ui.form.on("Good", {
     refresh(frm) {
-        frm.add_custom_button(__("Sent Email"), function () {
+        frm.add_custom_button(__("Send Email"), function () {
             // console.log("create new supplier");
             frappe.call({
                 method: "cbam.send_email_from_good.send_email",

--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -190,8 +190,7 @@
    "fieldname": "good_values",
    "fieldtype": "Select",
    "label": "Good Components",
-   "options": "Only one Component\nVarious Components",
-   "read_only": 1
+   "options": "Only one Component\nVarious Components"
   },
   {
    "fieldname": "column_break_kaso",
@@ -555,6 +554,7 @@
   {
    "fieldname": "add_operating_company_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Add Operating Company"
   },
   {
@@ -565,6 +565,7 @@
   {
    "fieldname": "add_installations_and_emission_data_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Add Installations and Emission Data"
   },
   {
@@ -580,7 +581,7 @@
    "link_fieldname": "supplier"
   }
  ],
- "modified": "2024-10-08 10:13:05.306165",
+ "modified": "2024-10-09 09:07:40.543076",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Good",

--- a/cbam/cbam/doctype/good/good.py
+++ b/cbam/cbam/doctype/good/good.py
@@ -47,7 +47,7 @@ class Good(Document):
 			next_highest_split_number = 0
 			if total_raw_mass != self.raw_mass:
 				original_raw_mass = self.raw_mass
-				frappe.throw(f"The raw mass total of the components is not equal to the raw mass of the original good. <br><br> The total should be {original_raw_mass}, not {total_raw_mass}. <br><br> Please change the raw masses of the components and ensure that they add up to a total of {original_raw_mass}")
+				frappe.throw(f"The raw mass total of the components is not equal to the raw mass of the original good. <br><br> The total should be {original_raw_mass}, not {total_raw_mass}. <br><br> Please change the raw masses of the components and ensure that they add up to a total of {original_raw_mass}.")
 			else:
 				self.status = "Done"
 				if self.split_raw_mass_1 and self.split_raw_mass_1 != "0":

--- a/cbam/cbam/doctype/supplier_employee/supplier_employee.js
+++ b/cbam/cbam/doctype/supplier_employee/supplier_employee.js
@@ -10,7 +10,7 @@
 
 frappe.ui.form.on("Supplier Employee", {
 	refresh(frm) {
-		frm.add_custom_button(__("Sent Email"), function () {
+		frm.add_custom_button(__("Send Email"), function () {
 			frappe.call({
 				method: "cbam.send_email_from_employee.create_user_and_send_email", // OPEN
 				args: {

--- a/cbam/cbam/web_form/complete_goods_data/complete_goods_data.js
+++ b/cbam/cbam/web_form/complete_goods_data/complete_goods_data.js
@@ -51,6 +51,8 @@ frappe.ready(function() {
 		callback: (r) => {
 			if (r.message.isOperatingCompanyRegistered && r.message.isOperatingCompanyRegistered == 1) {
 				frappe.web_form.set_df_property("add_operating_company_section", "hidden", 1);
+			} else {
+				frappe.web_form.set_df_property("add_installations_and_emission_data_section", "hidden", 1);
 			}
 		}
 	});

--- a/cbam/cbam/web_form/complete_goods_data/complete_goods_data.json
+++ b/cbam/cbam/web_form/complete_goods_data/complete_goods_data.json
@@ -42,7 +42,7 @@
  "list_title": "Your Goods",
  "login_required": 1,
  "max_attachment_size": 0,
- "modified": "2024-10-08 11:46:43.142963",
+ "modified": "2024-10-09 09:36:39.412919",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "complete-goods-data",
@@ -106,7 +106,7 @@
    "max_length": 0,
    "max_value": 0,
    "precision": "",
-   "read_only": 0,
+   "read_only": 1,
    "reqd": 0,
    "show_in_filter": 0
   },
@@ -120,7 +120,7 @@
    "max_value": 0,
    "precision": "",
    "read_only": 1,
-   "read_only_depends_on": "eval:doc.status=='Done'",
+   "read_only_depends_on": "",
    "reqd": 0,
    "show_in_filter": 0
   },
@@ -286,7 +286,7 @@
    "precision": "",
    "read_only": 0,
    "read_only_depends_on": "eval:doc.status=='Done'",
-   "reqd": 0,
+   "reqd": 1,
    "show_in_filter": 0
   },
   {
@@ -791,12 +791,13 @@
   },
   {
    "allow_read_on_all_link_options": 0,
+   "depends_on": "eval:doc.good_values==\"Only one Component\"",
    "fieldtype": "HTML",
    "hidden": 0,
    "label": "Add oc data",
    "max_length": 0,
    "max_value": 0,
-   "options": "<a href=\"/add-operating-company-data/new\" class=\"btn btn-primary btn-sm primary-action mb-5\" target=\"\">Add all Emission Data</a>",
+   "options": "<a href=\"/add-operating-company-data/new\" class=\"btn btn-primary btn-sm primary-action mb-5\" target=\"\">Add Emission Data</a>",
    "precision": "",
    "read_only": 0,
    "reqd": 0,
@@ -817,6 +818,7 @@
   },
   {
    "allow_read_on_all_link_options": 0,
+   "depends_on": "eval:doc.good_values==\"Only one Component\"",
    "fieldtype": "HTML",
    "hidden": 0,
    "label": "Add Installation",
@@ -830,6 +832,7 @@
   },
   {
    "allow_read_on_all_link_options": 0,
+   "depends_on": "eval:doc.good_values==\"Only one Component\"",
    "fieldtype": "HTML",
    "hidden": 0,
    "label": "Add Emission Data",

--- a/cbam/create_email.py
+++ b/cbam/create_email.py
@@ -3,18 +3,10 @@ from frappe.core.doctype.communication.email import make
 
 
 def create_email(employee):
-    # frappe.msgprint(f"Good: {good}, Supplier: {supplier}")
     domain = "https://cbam-dev.frappe.cloud/"
-    # supplier_doc = frappe.get_doc("Supplier", supplier)
-    # for good in supplier_doc.goods:
-    #     frappe.db.set_value('Good', good.good_number, 'sent_to_supplier_employee', 'Sent')
-    # employee = frappe.db.get_value("Good", good, "employee")
-    #is_data_confirmed_employee = frappe.db.get_value('Supplier Employee', employee, 'is_data_confirmed')
+
     employee_email = frappe.db.get_value('Supplier Employee', employee, 'email')
     employee_last_name = frappe.db.get_value('Supplier Employee', employee, 'last_name')
-    # is_employee_main_contact = frappe.db.get_value('Supplier Employee', employee, 'is_main_contact')
-    # if is_employee_main_contact:
-    #     frappe.db.set_value('Supplier', supplier, 'status', "Sent for confirmation")
 
 
     subject = f'CBAM - Confirmation of Data'

--- a/cbam/www/style.css
+++ b/cbam/www/style.css
@@ -2,7 +2,7 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    font-family: Arial, sans-serif;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
 body {
@@ -46,6 +46,7 @@ button {
     color: #333;
     background-color: #fff;
     border: 1px solid #333;
+    border-radius: 6px;
     cursor: pointer;
 }
 


### PR DESCRIPTION
### Minor Improvements to Web Forms and Frappe UI
- Frappe UI: Corrected typos in the "Send Email" button.
- Web Form Goods: Set the "Invoice Number" field to read-only.
- Web Form Goods: Updated logic for displaying either the "Add Emission Data" button or both the "Add Additional Installation" and "Add Additional Emission Data" buttons.
![image](https://github.com/user-attachments/assets/5e28f1d4-641e-49f3-a3de-75af36f84f0d)
