### PR TITLE
feat(45): Main Contact Logic in Supplier Child Table Employees

### DIFF
--- a/cbam/cbam/doctype/supplier/supplier.js
+++ b/cbam/cbam/doctype/supplier/supplier.js
@@ -30,30 +30,27 @@
 frappe.ui.form.on('Supplier', {
 	refresh(frm) {
 		if(frappe.user.has_role("System Manager")){
-
-			
 			frm.add_custom_button(__("Delete All Employees"), function(){
-				frappe.msgprint({
-					title: __('Delete All Employees?'),
-					message: __('This will delete all the linked employees. Are you sure you want to proceed?'),
-					primary_action_label: __("Proceed"),
-					indicator:'red',
-					primary_action:{
-						
-						action(values) {
-							frappe.call({
-								method: "delete_linked_employees",
-								doc: frm.doc,
-								callback(r){
-									msgprint(__("Deleted all employees successfully."))
+				frappe.warn( 
+					__('Are you sure you want to proceed?'),
+					__('This will delete all the linked employees.'),
+					() => {
+						frappe.call({
+							method: "delete_linked_employees",
+							doc: frm.doc,
+							freeze: true,
+							freeze_message: "Deleting Linked Empoyees, please wait ....",
+							callback(r){
+								if(r.message){
+									frm.reload_doc()
+									msgprint(r.message)
 								}
-							});
-						}
-					}
-				});
+							}
+						});
+					}, () => {
+				})
 			})
 		}
-		
 	}
 })
 


### PR DESCRIPTION
Fixes:
- Changed the dialog to frappe.warn from frappe.msgprint for enhancements:
![image](https://github.com/user-attachments/assets/48172bf9-f08f-455d-ae00-f8a1b88fcb0b)

- Also set the form to auto refresh after the employees are deleted.
 