### PR TITLE
feat(22):update-childtables-in-several-Doctypes-after-altering-data

### DIFF
--- a/cbam/cbam/doctype/cbam_emission_data/cbam_emission_data.json
+++ b/cbam/cbam/doctype/cbam_emission_data/cbam_emission_data.json
@@ -134,7 +134,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-08 13:19:31.597297",
+ "modified": "2024-10-24 10:03:12.160836",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "CBAM Emission Data",
@@ -156,5 +156,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/cbam/cbam/doctype/cbam_installation/cbam_installation.json
+++ b/cbam/cbam/doctype/cbam_installation/cbam_installation.json
@@ -301,7 +301,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-21 09:38:31.706732",
+ "modified": "2024-10-24 10:03:01.629321",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "CBAM Installation",
@@ -323,5 +323,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/cbam/cbam/doctype/cbam_operating_company/cbam_operating_company.json
+++ b/cbam/cbam/doctype/cbam_operating_company/cbam_operating_company.json
@@ -187,7 +187,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-16 15:16:16.821473",
+ "modified": "2024-10-24 10:00:09.427689",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "CBAM Operating Company",
@@ -209,5 +209,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/cbam/cbam/doctype/customs_import/customs_import.json
+++ b/cbam/cbam/doctype/customs_import/customs_import.json
@@ -35,10 +35,10 @@
  "links": [
   {
    "link_doctype": "Good",
-   "link_fieldname": "good_number"
+   "link_fieldname": "internal_customs_import_number"
   }
  ],
- "modified": "2024-09-06 20:28:11.774005",
+ "modified": "2024-10-24 09:59:16.616143",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Customs Import",
@@ -60,5 +60,6 @@
  ],
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/cbam/cbam/doctype/good/good.js
+++ b/cbam/cbam/doctype/good/good.js
@@ -10,8 +10,18 @@ frappe.ui.form.on('Good', {
                 }
             }
         });
+    },
+    refresh(frm) {
+        frm.set_query("employee", (doc) => {
+            return {
+                filters: {
+                    "supplier_company": doc.supplier
+                }
+            }
+        });
     }
 })
+
 
 frappe.ui.form.on('Good', {
     installation(frm) {

--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -434,6 +434,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Status",
    "options": "Raw Data\nSent for completing\nSplit\nDone",
    "read_only": 1
@@ -575,7 +576,7 @@
    "link_fieldname": "supplier"
   }
  ],
- "modified": "2024-10-22 10:55:16.036642",
+ "modified": "2024-10-24 09:59:58.952106",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Good",
@@ -615,5 +616,6 @@
    "color": "Green",
    "title": "Done"
   }
- ]
+ ],
+ "track_changes": 1
 }

--- a/cbam/cbam/doctype/supplier/supplier.json
+++ b/cbam/cbam/doctype/supplier/supplier.json
@@ -66,6 +66,8 @@
    "description": "Raw Data = Not sent to the Main Contact Employee yet.<br>After sending, the data cannot be changed anymore.",
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Status",
    "options": "Raw Data\nSent for confirmation\nConfirmed",
    "read_only": 1
@@ -225,7 +227,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-16 10:22:13.728176",
+ "modified": "2024-10-24 09:57:07.071296",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Supplier",

--- a/cbam/cbam/doctype/supplier_employee/supplier_employee.json
+++ b/cbam/cbam/doctype/supplier_employee/supplier_employee.json
@@ -79,6 +79,8 @@
    "description": "Raw Data =  Not sent to the Employee yet. <br>After sending, the data cannot be changed anymore.\n",
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Status",
    "options": "Raw Data\nSent to Supplier Employee\nData confirmed by Employee",
    "read_only": 1
@@ -122,7 +124,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-14 18:06:00.689173",
+ "modified": "2024-10-24 09:59:45.239615",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Supplier Employee",
@@ -157,5 +159,6 @@
    "color": "Green",
    "title": "Data confirmed by Employee"
   }
- ]
+ ],
+ "track_changes": 1
 }

--- a/cbam/cbam/web_template/cbam_footer/cbam_footer.html
+++ b/cbam/cbam/web_template/cbam_footer/cbam_footer.html
@@ -9,7 +9,7 @@
                     <li><a href="terms-and-conditions" style="text-decoration: none; color: inherit;">Terms and Conditions</a></li>
                 </ul>
             </div>
-            <div class="col-sm-6 col-12">
+            <div class="col-sm-6 col-12 mt-3">
                 © Gallehr &amp; Partners GmbH
             </div>
         </div>


### PR DESCRIPTION
### Changes on one glance:
- Added "Track Changes" to all CBAM doctyps
- Added Status fields as "In List Filter" in the doctypes "Supplier", "Supplier Employee", "Good"
- Goods.js: I added a function to filter the employee fields for suppliers not only when the supplier is changed, but also on refresh (in case somebody want to choose another employee from the same company)
- Goods.py: Added the function to update the child table entries data (supplier, employee, status), whenever the good document is changed, in the following docypes:
  - Custom Import
  - Supplier
  - Employee