### PR TITLE
bugfix/114&147-security-and-imprint-link

### DIFF
--- a/cbam/cbam/doctype/supplier/supplier.py
+++ b/cbam/cbam/doctype/supplier/supplier.py
@@ -9,7 +9,6 @@ from frappe.utils import cstr
 from frappe import _
 class Supplier(Document):
 	def before_insert(self):
-		
 		self.sub_supplier()
 		self.add_doc_name_as_supplier_number()
 
@@ -29,7 +28,6 @@ class Supplier(Document):
 
 #	def validate(self):
 #		pass
-	
 
 
 	# def after_insert(self):

--- a/cbam/cbam/web_template/cbam_footer/cbam_footer.html
+++ b/cbam/cbam/web_template/cbam_footer/cbam_footer.html
@@ -4,9 +4,9 @@
         <div class="row">
             <div class="footer-links col-12">
                 <ul style="list-style-type: none; padding: 0; margin: 0; padding-top: 0; margin-top: -40px; text-align: left">
-                    <li><a href="imprint" style="text-decoration: none; color: inherit;">Imprint</a></li>
-                    <li><a href="privacy-policy" style="text-decoration: none; color: inherit;">Privacy Policy</a></li>
-                    <li><a href="terms-and-conditions" style="text-decoration: none; color: inherit;">Terms and Conditions</a></li>
+                    <li><a href="/imprint" style="text-decoration: none; color: inherit;">Imprint</a></li>
+                    <li><a href="/privacy-policy" style="text-decoration: none; color: inherit;">Privacy Policy</a></li>
+                    <li><a href="/terms-and-conditions" style="text-decoration: none; color: inherit;">Terms and Conditions</a></li>
                 </ul>
             </div>
             <div class="mt-3">

--- a/cbam/send_email/create_new_supplier_user.py
+++ b/cbam/send_email/create_new_supplier_user.py
@@ -18,9 +18,11 @@ def create_new_supplier_user(employee):
             new_user.append("roles", {
                 'role': 'Supplier'
             })
-      
+
             new_user.save(ignore_permissions=True)
-            frappe.db.set_value("Supplier Employee", employee_doc.name, "Status", "Sent to Supplier Employee")
+            frappe.db.set_value("Supplier Employee", employee_doc.name, "status", "Sent to Supplier Employee")
+            frappe.db.set_value("Supplier Employee", employee_doc.name, "owner", employee_doc.email)
+            frappe.db.set_value("Supplier", employee_doc.supplier_company, "owner", employee_doc.email)
         except Exception as e:
             frappe.log_error(frappe.get_traceback(), f"An error occured while creating user for {employee_doc.name}")
-       
+

--- a/cbam/send_email/create_new_supplier_user.py
+++ b/cbam/send_email/create_new_supplier_user.py
@@ -22,7 +22,9 @@ def create_new_supplier_user(employee):
             new_user.save(ignore_permissions=True)
             frappe.db.set_value("Supplier Employee", employee_doc.name, "status", "Sent to Supplier Employee")
             frappe.db.set_value("Supplier Employee", employee_doc.name, "owner", employee_doc.email)
-            frappe.db.set_value("Supplier", employee_doc.supplier_company, "owner", employee_doc.email)
+            is_main_contact = frappe.db.get_value("Supplier Employee", employee_doc.name, "is_main_contact")
+            if is_main_contact:
+                frappe.db.set_value("Supplier", employee_doc.supplier_company, "owner", employee_doc.email)
         except Exception as e:
             frappe.log_error(frappe.get_traceback(), f"An error occured while creating user for {employee_doc.name}")
 


### PR DESCRIPTION
### Bugfix 114 - access to list of all installations/emissions
#### Problem: 
Since the Suppliers from the last PR only have access to their own Documents, it was not possible anymore to confirm the supplier and supplier employee data. 
#### Solution: 
When a supplier user is created, the owner of "Supplier employee" and (if main employee) "Supplier" is changed to this user. 

### Bugfix 147 - Impressum Text
#### Problem: 
The link didn't work when you clicked on it inside Goods. 
#### Solution: 
Adding a / to the link. 