### PR TITLE
Bugfix-main-employee-set-automatically-before-save

### DIFF
--- a/cbam/cbam/doctype/good/good.py
+++ b/cbam/cbam/doctype/good/good.py
@@ -13,7 +13,7 @@ class Good(Document):
 
 	def before_save(self):
 		self.delete_old_employee_if_supplier_changed()
-		
+		self.get_main_contact_employee()
 		if self.is_data_confirmed == True and self.manufacture == "I am the manufacture":
 			self.status = "Done"
 		self.add_to_supplier_cht()


### PR DESCRIPTION
Doctype Good: The function of adding automatically the Main Contact of the Supplier to the field "employee" didn't work since it was not added to the controllers any more. I added it again.