### PR TITLE
gallehr/cbam#406: Corrected Edit Button Logic to Fetch Clicked Document in Emission Data

### DIFF
--- a/cbam/www/installation_list/index.js
+++ b/cbam/www/installation_list/index.js
@@ -482,8 +482,9 @@ function executeJS() {
                 });
             }
             
-            if(e.target.classList.contains("edit-emission")) {
-                const docName = container.querySelector(".edit-emission").dataset.emission;
+            if(e.target.classList.contains("edit-emission")) { 
+                // const docName = container.querySelector(".edit-emission").dataset.emission;
+                const docName = e.target.dataset.emission;
                 frappe.call({
                     method: "frappe.client.get",
                     args: {


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/406
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/400

**Description:**

- Updated the logic to fetch data-emission directly from the clicked button (e.target) instead of using container.querySelector().
- Ensures the correct document name is retrieved when multiple "Edit" buttons exist on the page.
- No functional changes to the UI; safer and more reliable event handling.