### PR TITLE
bug fix gallehr/cbam#454: Installation shown in Supplier Selection in split goods

### DIFF
--- a/cbam/utils/links.py
+++ b/cbam/utils/links.py
@@ -3,7 +3,7 @@ import frappe
 @frappe.whitelist()
 def get_links(doctype, filters={}, fields=[]):
     if not fields:
-        fields = ["name as label", "name as value"]
+        fields = ["name as value", "name_of_the_installation as label"]
     return frappe.get_list(doctype, fields=fields, filters=filters)
 
 @frappe.whitelist()

--- a/cbam/www/goods_list/index.js
+++ b/cbam/www/goods_list/index.js
@@ -482,6 +482,22 @@ function executeJS() {
 
                    
         d.show();
+        // Patch click event on rows to update source_name options on click
+        d.fields_dict.table1.grid.wrapper.on('click', '.grid-row', async function (e) {
+            const name = $(this).attr('data-name');
+            const row = d.fields_dict.table1.grid.grid_rows_by_docname[name];
+
+            if (!row || !row.doc.source) return;
+
+            let options = [];
+            if (row.doc.source === "Supplier") {
+                row.columns.source_name.df.options= await cbam.supplier.get_child_suppliers();
+            } else if (row.doc.source === "Installation") {
+                row.columns.source_name.df.options= await cbam.utils.get_links("CBAM Installation");
+            }
+            // row.columns.source_name.df.options = options;
+            d.fields_dict.table1.grid.refresh();
+        });
     }
 
     const toggleDataBtn = function(toggle) {


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/issues/454


This update enhances the Split Goods dialog by dynamically filtering source_name options based on the selected source type (Supplier or Installation). Key improvements:

- Added a click event listener on each dialog table row.

- When a row is clicked:

  -  If source is Supplier, it fetches supplier-specific options.

  - If source is Installation, it fetches installation records.

- Ensures source_name dropdown updates per row without relying on unreliable onchange or onfocus events in non-editable grid.

- Improves user experience by showing only relevant and valid options.

