### PR TITLE
gallehr/cbam#476: New Doctype to capture ETS pricing data

### DIFF
--- a/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.js
+++ b/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, phamos GmbH and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("ETS Carbon Price", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.json
+++ b/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.json
@@ -1,0 +1,56 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-06-03 08:35:23.402476",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "date",
+  "price",
+  "ets_price_type"
+ ],
+ "fields": [
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "label": "Date"
+  },
+  {
+   "fieldname": "price",
+   "fieldtype": "Currency",
+   "label": "Price"
+  },
+  {
+   "fieldname": "ets_price_type",
+   "fieldtype": "Select",
+   "label": "ETS price Type",
+   "options": "\nActual\nPrediction"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-06-03 11:28:24.891656",
+ "modified_by": "Administrator",
+ "module": "CBAM",
+ "name": "ETS Carbon Price",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.json
+++ b/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.json
@@ -1,10 +1,12 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "naming_series:naming_series",
  "creation": "2025-06-03 08:35:23.402476",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "naming_series",
   "date",
   "price",
   "ets_price_type"
@@ -25,15 +27,23 @@
    "fieldtype": "Select",
    "label": "ETS price Type",
    "options": "\nActual\nPrediction"
+  },
+  {
+   "default": "ETS-CP-",
+   "fieldname": "naming_series",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Naming Series"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-03 11:28:24.891656",
+ "modified": "2025-06-03 12:30:40.539393",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "ETS Carbon Price",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {

--- a/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.py
+++ b/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, phamos GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ETSCarbonPrice(Document):
+	pass

--- a/cbam/cbam/doctype/ets_carbon_price/test_ets_carbon_price.py
+++ b/cbam/cbam/doctype/ets_carbon_price/test_ets_carbon_price.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, phamos GmbH and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestETSCarbonPrice(FrappeTestCase):
+	pass

--- a/cbam/cbam/doctype/external_good/external_good.json
+++ b/cbam/cbam/doctype/external_good/external_good.json
@@ -85,15 +85,14 @@
   },
   {
    "fieldname": "country",
-   "fieldtype": "Link",
-   "label": "Country",
-   "options": "Country"
+   "fieldtype": "Data",
+   "label": "Country"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-02 11:14:58.883331",
+ "modified": "2025-06-03 11:39:43.408297",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "External Good",

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.py
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.py
@@ -49,34 +49,38 @@ def get_columns():
 			"fieldtype": "Data",
 			"label": "Buying Price per Mass"
 		},
-        {
-		
-			"fieldname": "emission_value",
-			"fieldtype": "Data",
-			"label": "Standard Emission Value"
-		},
+       
 		{
 		
 			"fieldname": "real_emission_value",
 			"fieldtype": "Data",
 			"label": "Real Emission Value"
 		},
-        {
-			"fieldname": "bench_mark",
-			"fieldtype": "Data",
-			"label": "Benchmark"
-		},
+       
 		{
 			"fieldname": "carbon_price_due",
 			"fieldtype": "Data",
 			"label": "Carbon Price Due"
-		}
+		},
+        {
+			"fieldname": "ets_carbon_price",
+			"fieldtype": "Data",
+			"label": "ETS Carbon Price"
+		},
 	]
              
     return columns
 
 def get_data():
-    data = frappe.db.sql("""
+    
+    ets_carbon_price = frappe.db.get_value(
+        "ETS Carbon Price",
+        {"ets_price_type": "Actual"},
+        "price",
+        order_by="date desc"
+    ) or 0
+    
+    data = frappe.db.sql(f"""
         SELECT 
             eg.cn_code AS cn_number,
             eg.article_no AS article_number,
@@ -86,16 +90,16 @@ def get_data():
             eg.mass_per_article,
             eg.buying_price_per_mass AS buying_price,
             eg.carbon_price_due,
-                         eg.real_emissions_value as real_emission_value,
+            eg.real_emissions_value as real_emission_value,
 			e.emission_value,
-        b.bench_mark
+        	b.bench_mark,
+			{ets_carbon_price} AS ets_carbon_price
         FROM `tabExternal Good` eg
 		join `tabStandard Emission Value`
 		as e on eg.cn_code = e.cn_code and eg.country = e.country
 		join `tabCN Code Bench Mark` as b
-		on b.cn_code = eg.cn_code
+		on b.cn_code = eg.cn_code              
         UNION ALL
-
         SELECT 
             g.customs_tariff_number AS cn_number,
             g.article_number,
@@ -106,15 +110,17 @@ def get_data():
             g.buying_price,
             g.carbon_price_due,
 			e.emission_value,
-                         g.specific_direct_embedded_emissions as real_emission_value,
-            b.bench_mark
+            g.specific_direct_embedded_emissions as real_emission_value,
+            b.bench_mark,
+            {ets_carbon_price} AS ets_carbon_price
         FROM `tabGood` g 
-                         join `tabStandard Emission Value`
-                         as e on g.customs_tariff_number = e.cn_code and g.country_of_origin = e.country
-                         join `tabCN Code Bench Mark` as b
-                         on b.cn_code = g.customs_tariff_number
+			join `tabStandard Emission Value`
+			as e on g.customs_tariff_number = e.cn_code and g.country_of_origin = e.country
+			join `tabCN Code Bench Mark` as b
+			on b.cn_code = g.customs_tariff_number
     """, as_dict=1)
 
     return data
+
 
 


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/476
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/436

**Changes Made**

- New Doctype: ETS Carbon Price
    -  Fields: date, price (in €), ets_price_type (Actual or Prediction)

- **SQL Report Enhancement:**
    -  Injects the latest "Actual" ETS Carbon Price (based on the most recent date) into the report output.

    -  Adds a new column latest_ets_price to each row.

    -  Enables derived metrics like carbon_cost = emission_value × latest_ets_price.