### PR TITLE
gallehr/cbam#454: updated name field in Split Details(Good)

### DIFF
--- a/cbam/cbam/doctype/good/good.py
+++ b/cbam/cbam/doctype/good/good.py
@@ -24,6 +24,18 @@ class Good(Document):
 		if self.operating_company:
 			self.supplier_number, self.supplier_name = frappe.db.get_values("Operating Company", self.operating_company, ['supplier_number', 'supplier_name'])[0]
 
+		self.update_name()
+
+	def update_name(self):
+		for row in self.split_details:
+			if not row.source_name:
+				continue
+
+			if row.source == "Operating Company":
+				row.name_ = frappe.db.get_value("Operating Company", row.source_name, "supplier_name")
+			elif row.source == "CBAM Installation":
+				row.name_ = frappe.db.get_value("CBAM Installation", row.source_name, "name_of_the_installation")
+
 	def set_countries(self):
 		self.country_of_origin = frappe.db.get_value("Country", {"code": self.country_of_origin_code}, "name")
 		self.shipping_country = frappe.db.get_value("Country", {"code": self.shipping_country_code}, "name")

--- a/cbam/cbam/doctype/good_split_detail/good_split_detail.json
+++ b/cbam/cbam/doctype/good_split_detail/good_split_detail.json
@@ -8,6 +8,7 @@
  "field_order": [
   "source",
   "source_name",
+  "name_",
   "qty_to_split"
  ],
  "fields": [
@@ -33,18 +34,26 @@
    "in_list_view": 1,
    "label": "Qty to Split [Kg]",
    "read_only": 1
+  },
+  {
+   "fieldname": "name_",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Name",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-16 08:36:14.936867",
+ "modified": "2025-06-03 13:18:02.991643",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Good Split Detail",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/cbam/www/goods_list/index.js
+++ b/cbam/www/goods_list/index.js
@@ -302,6 +302,21 @@ function executeJS() {
                             fieldname: `source_name`,
                             fieldtype: "Select",
                             reqd: 1,  
+                            in_list_view: 1,
+                            onchange: (event) => {
+                                const selectedOption = event.currentTarget.selectedOptions[0];
+                                const label = selectedOption?.label || "";
+                                const name = $(event.currentTarget).closest(".grid-row").attr("data-name");
+                                let row = d.fields_dict.table1.grid.grid_rows_by_docname[name];
+                                if (row) row.doc.name_ = label;
+                                d.fields_dict.table1.grid.refresh();
+                            }
+                        },
+                        {
+                            label: __("Name"),
+                            fieldname: "name_",
+                            fieldtype: "Data", 
+                            read_only: 1,
                             in_list_view: 1
                         },
                         {


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/issues/454

This PR introduces the Name field in both the Split Goods dialog and the Good Doctype (split_details child table). The field auto-fills based on the selected source and source_name.

**Split Goods dialog**

![image](https://github.com/user-attachments/assets/6d7acaf0-5169-46ed-aa1a-92fc8f39d790)

**Good Doctype:**

<img width="1304" alt="Screenshot 2025-06-03 at 7 53 44 PM" src="https://github.com/user-attachments/assets/a20cea7a-7d28-493f-85d0-4c84eb6df9fc" />
