### PR TITLE
gallehr/cbam#479: updated workspace permission

### DIFF
--- a/cbam/hooks.py
+++ b/cbam/hooks.py
@@ -66,6 +66,7 @@ after_migrate = [
     "cbam.utils.utils.update_workspace_for_helpdesk",
     "cbam.utils.utils.add_helpdesk_navbar_item",
     "cbam.utils.utils.remove_user_access_for_desk_user",
+    "cbam.utils.utils.update_helpdesk_workspace_roles",
 ]
 # Svg Icons
 # ------------------

--- a/cbam/utils/utils.py
+++ b/cbam/utils/utils.py
@@ -52,3 +52,34 @@ def remove_user_access_for_desk_user():
         print(f"Removed permission: {perm.name}")
 
     frappe.db.commit()
+
+
+def update_helpdesk_workspace_roles():
+    # Check if "Helpdesk" workspace exists
+    if not frappe.db.exists("Workspace", "Helpdesk"):
+        return
+
+    # Fetch the document
+    ws = frappe.get_doc("Workspace", "Helpdesk")
+
+    # Get current roles already assigned (as a set for fast lookup)
+    existing_roles = {r.role for r in ws.roles}
+
+    # Define required roles
+    required_roles = ["System Manager", "Administrator"]
+
+    # Track if we make changes
+    updated = False
+
+    # Append roles only if not already present
+    for role in required_roles:
+        if role not in existing_roles:
+            ws.append("roles", {"role": role})
+            updated = True
+
+    # Save and commit only if any change
+    if updated:
+        ws.is_hidden = 0
+        ws.save(ignore_permissions=True)
+        frappe.db.commit()
+        print("Updated roles in 'Helpdesk' workspace.")


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/issues/479

**🎯 Purpose**

Ensure that the Helpdesk workspace in the sidebar is only visible to users with appropriate roles.

**✅ What Was Done**

- Updated the Workspace: Helpdesk document to include only:
  - System Manager
  - Administrator
    in its roles child table.

- Added backend logic to enforce this restriction by programmatically updating the workspace roles.
- Ensured is_hidden = 0 to make it visible only to those roles.
- Hooked the update function to after_migrate to apply automatically when:

  - Helpdesk is installed,
  - Or on any subsequent bench migrate.