### PR TITLE
Gallehr/cbam#483

### DIFF
--- a/cbam/cbam/doctype/declarant/declarant.py
+++ b/cbam/cbam/doctype/declarant/declarant.py
@@ -1,9 +1,31 @@
 # Copyright (c) 2025, phamos GmbH and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
-
+from frappe import _
 
 class Declarant(Document):
-	pass
+    def validate(self):
+        self.ensure_unique_user_across_declarants()
+
+    def ensure_unique_user_across_declarants(self):
+        for user_row in self.get("declarant_user"):
+            user = user_row.user
+            if not user:
+                continue
+
+            existing = frappe.db.exists(
+                "Declarant User",
+                {
+                    "user": user,
+                    "parent": ["!=", self.name]
+                }
+            )
+
+            if existing:
+                linked_doc = frappe.db.get_value("Declarant User", existing, "parent")
+                frappe.throw(
+                    _("User <b>{0}</b> is already linked to another Declarant: <b>{1}</b>").format(user, linked_doc),
+                    title=_("Validation Error")
+                )

--- a/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.json
+++ b/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.json
@@ -7,20 +7,22 @@
  "engine": "InnoDB",
  "field_order": [
   "naming_series",
+  "creation_date",
   "date",
   "price",
-  "ets_price_type"
+  "ets_price_type",
+  "carbon_price_source"
  ],
  "fields": [
   {
    "fieldname": "date",
    "fieldtype": "Date",
-   "label": "Date"
+   "label": "Price Date"
   },
   {
    "fieldname": "price",
    "fieldtype": "Currency",
-   "label": "Price"
+   "label": "ETS Carbon Price [\u20ac/tCO2]"
   },
   {
    "fieldname": "ets_price_type",
@@ -34,12 +36,23 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "Naming Series"
+  },
+  {
+   "fieldname": "creation_date",
+   "fieldtype": "Date",
+   "label": "Creation Date"
+  },
+  {
+   "fieldname": "carbon_price_source",
+   "fieldtype": "Link",
+   "label": "ETS Carbon Price Source",
+   "options": "ETS Carbon Price Source"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-03 12:30:40.539393",
+ "modified": "2025-06-12 08:44:01.522236",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "ETS Carbon Price",

--- a/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.json
+++ b/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.json
@@ -8,17 +8,12 @@
  "field_order": [
   "naming_series",
   "creation_date",
-  "date",
+  "price_date",
   "price",
   "ets_price_type",
   "carbon_price_source"
  ],
  "fields": [
-  {
-   "fieldname": "date",
-   "fieldtype": "Date",
-   "label": "Price Date"
-  },
   {
    "fieldname": "price",
    "fieldtype": "Currency",
@@ -28,7 +23,8 @@
    "fieldname": "ets_price_type",
    "fieldtype": "Select",
    "label": "ETS price Type",
-   "options": "\nActual\nPrediction"
+   "options": "\nActual\nPrediction",
+   "set_only_once": 1
   },
   {
    "default": "ETS-CP-",
@@ -40,19 +36,27 @@
   {
    "fieldname": "creation_date",
    "fieldtype": "Date",
-   "label": "Creation Date"
+   "label": "Creation Date",
+   "read_only": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "carbon_price_source",
    "fieldtype": "Link",
    "label": "ETS Carbon Price Source",
    "options": "ETS Carbon Price Source"
+  },
+  {
+   "fieldname": "price_date",
+   "fieldtype": "Date",
+   "label": "Price Date",
+   "set_only_once": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-12 08:44:01.522236",
+ "modified": "2025-06-12 09:54:30.429986",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "ETS Carbon Price",

--- a/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.py
+++ b/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.py
@@ -1,9 +1,31 @@
 # Copyright (c) 2025, phamos GmbH and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
-
+from frappe.model.naming import make_autoname
+from frappe.utils import today, formatdate
 
 class ETSCarbonPrice(Document):
-	pass
+	def autoname(self):
+		if not self.ets_price_type:
+			frappe.throw("ETS Price Type (Actual or Prediction) is required.")
+
+		if not self.price_date:
+			frappe.throw("ETS Carbon Price Date is required.")
+
+        # Map Actual / Prediction to A / P
+		type_code = "A" if self.ets_price_type == "Actual" else "P"
+		price_date_str = formatdate(self.price_date, "yyyy-MM-dd")
+
+        # Use Frappe's counter mechanism with date series
+		creation_date_str = formatdate(self.creation, "yyyy-MM-dd")
+
+
+		counter_prefix = f"ETS-{creation_date_str}-.####"
+		counter_id = make_autoname(counter_prefix)
+
+		self.creation_date = self.creation or today()
+		self.name = f"{counter_id}-{type_code}-{price_date_str}"
+
+		

--- a/cbam/cbam/doctype/ets_carbon_price_source/ets_carbon_price_source.js
+++ b/cbam/cbam/doctype/ets_carbon_price_source/ets_carbon_price_source.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, phamos GmbH and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("ETS Carbon Price Source", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/cbam/cbam/doctype/ets_carbon_price_source/ets_carbon_price_source.json
+++ b/cbam/cbam/doctype/ets_carbon_price_source/ets_carbon_price_source.json
@@ -1,0 +1,46 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:source",
+ "creation": "2025-06-12 08:37:30.977047",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "source"
+ ],
+ "fields": [
+  {
+   "fieldname": "source",
+   "fieldtype": "Data",
+   "label": "Source",
+   "unique": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-06-12 08:40:31.090057",
+ "modified_by": "Administrator",
+ "module": "CBAM",
+ "name": "ETS Carbon Price Source",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/cbam/cbam/doctype/ets_carbon_price_source/ets_carbon_price_source.py
+++ b/cbam/cbam/doctype/ets_carbon_price_source/ets_carbon_price_source.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, phamos GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ETSCarbonPriceSource(Document):
+	pass

--- a/cbam/cbam/doctype/ets_carbon_price_source/test_ets_carbon_price_source.py
+++ b/cbam/cbam/doctype/ets_carbon_price_source/test_ets_carbon_price_source.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, phamos GmbH and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestETSCarbonPriceSource(FrappeTestCase):
+	pass

--- a/cbam/cbam/doctype/external_good/external_good.js
+++ b/cbam/cbam/doctype/external_good/external_good.js
@@ -2,14 +2,19 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("External Good", {
-	onload: function (frm) {
-        frm.set_query('declarant', () => {
-          return {
-            query: 'cbam.utils.utils.get_declarant_for_user',
-            filters: {
-              user: frappe.session.user
-            }
-          };
-        });
-      }
+  onload: function (frm) {
+    if (frappe.session.user != "Administrator") {
+      frm.set_df_property('declarant', 'read_only', 1);
+    }
+    if (frappe.session.user != "Administrator" && frm.doc.__islocal) {
+      frappe.call({
+        method: "cbam.utils.utils.get_declarant_for_user",
+        callback: function (r) {
+          if (r.message) {
+            frm.set_value('declarant', r.message[0]);
+          }
+        }
+      });
+    }
+  }
 });

--- a/cbam/cbam/doctype/external_good/external_good.json
+++ b/cbam/cbam/doctype/external_good/external_good.json
@@ -92,14 +92,16 @@
   {
    "fieldname": "declarant",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Declarant",
-   "options": "Declarant"
+   "options": "Declarant",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-11 09:12:27.722736",
+ "modified": "2025-06-12 07:31:34.321015",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "External Good",
@@ -127,7 +129,6 @@
    "read": 1,
    "report": 1,
    "role": "Declarant",
-   "select": 1,
    "share": 1,
    "write": 1
   }

--- a/cbam/cbam/doctype/external_good/external_good.py
+++ b/cbam/cbam/doctype/external_good/external_good.py
@@ -11,7 +11,7 @@ class ExternalGood(Document):
 			self.declarant = None
 	
 	def is_user_allowed_declarant(self, declarant, user):
-		return frappe.db.exists("Declarant Users", {
+		return frappe.db.exists("Declarant User", {
 			"parent": declarant,
 			"user": user
 		})

--- a/cbam/utils/utils.py
+++ b/cbam/utils/utils.py
@@ -89,19 +89,12 @@ def user_permission_query(user):
     return "1=0"  # deny all rows
 
 @frappe.whitelist()
-def get_declarant_for_user(doctype, txt, searchfield, start, page_len, filters):
-    user = filters.get("user")
+def get_declarant_for_user():
+    user = frappe.session.user
+    declarants = frappe.get_all(
+        "Declarant User",
+        filters={"user": user},
+        pluck="parent"
+    )
+    return declarants
 
-    declarants = frappe.db.sql("""
-        SELECT parent
-        FROM `tabDeclarant User`
-        WHERE user = %s
-    """, (user,))
-
-    if not declarants:
-        return []
-
-    return [
-        (d[0],) for d in declarants
-        if txt.lower() in d[0].lower()
-    ]


### PR DESCRIPTION
Issue 1: https://git.phamos.eu/gallehr/cbam/-/issues/483

Issue 2: https://git.phamos.eu/gallehr/cbam/-/work_items/477
Parent: https://git.phamos.eu/gallehr/cbam/-/issues/436

Validation:

*  Creation Date field (read only, not document date as per screenshot)
*  Price date (rename of Date field)
*  change field name from "Price" to "ETS Carbon Price \[€/tCO2\]"
*  ID indicates type of Price and price date
*  System allows multiple sources for pricing data
*  New doctype: ETS Carbon Price Source
*  Managing of sources is in line with later fetching pricing data automated via APIs from multiple sources
*  Pricing data can be managed by date of updates in Reports (e.g. only show pricing predictions made is last two months)


![image](https://github.com/user-attachments/assets/e5dd96a5-dde5-4578-947b-6f9209dd473e)

![image](https://github.com/user-attachments/assets/5e128cc6-b61d-4a35-b50c-5ffc5e29a5b5)

