### PR TITLE
Gallehr/cbam#488: Refactor CN Code Handling: New Doctype and Field Standardization

### DIFF
--- a/cbam/cbam/doctype/cn_code/cn_code.js
+++ b/cbam/cbam/doctype/cn_code/cn_code.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, phamos GmbH and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("CN Code", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/cbam/cbam/doctype/cn_code/cn_code.json
+++ b/cbam/cbam/doctype/cn_code/cn_code.json
@@ -1,0 +1,54 @@
+{
+ "actions": [],
+ "autoname": "field:cn_code",
+ "creation": "2025-06-17 07:26:26.867769",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "cn_code",
+  "column_break_dkpq"
+ ],
+ "fields": [
+  {
+   "fieldname": "cn_code",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "CN Code",
+   "no_copy": 1,
+   "non_negative": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "column_break_dkpq",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-06-17 07:34:17.409092",
+ "modified_by": "Administrator",
+ "module": "CBAM",
+ "name": "CN Code",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/cbam/cbam/doctype/cn_code/cn_code.py
+++ b/cbam/cbam/doctype/cn_code/cn_code.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2025, phamos GmbH and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+from frappe import _
+
+class CNCode(Document):
+	def validate(self):
+		if self.cn_code and len(str(self.cn_code)) > 8:
+			frappe.throw(_("CN Code must be exactly 8 digits"))
+
+
+ 

--- a/cbam/cbam/doctype/cn_code/test_cn_code.py
+++ b/cbam/cbam/doctype/cn_code/test_cn_code.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, phamos GmbH and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestCNCode(FrappeTestCase):
+	pass

--- a/cbam/cbam/doctype/cn_code_bench_mark/cn_code_bench_mark.json
+++ b/cbam/cbam/doctype/cn_code_bench_mark/cn_code_bench_mark.json
@@ -13,8 +13,9 @@
  "fields": [
   {
    "fieldname": "cn_code",
-   "fieldtype": "Data",
-   "label": "CN Code"
+   "fieldtype": "Link",
+   "label": "CN Code",
+   "options": "CN Code"
   },
   {
    "fieldname": "bench_mark",
@@ -32,7 +33,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-13 08:07:01.933511",
+ "modified": "2025-06-17 07:55:32.693825",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "CN Code Bench Mark",

--- a/cbam/cbam/doctype/external_good/external_good.json
+++ b/cbam/cbam/doctype/external_good/external_good.json
@@ -24,8 +24,9 @@
  "fields": [
   {
    "fieldname": "cn_code",
-   "fieldtype": "Data",
-   "label": "CN Code"
+   "fieldtype": "Link",
+   "label": "CN Code",
+   "options": "CN Code"
   },
   {
    "fieldname": "article_no",
@@ -102,7 +103,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-13 08:15:17.235128",
+ "modified": "2025-06-17 07:41:53.940516",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "External Good",

--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -17,7 +17,7 @@
   "hand_over_date",
   "column_break_qjtl",
   "internal_customs_import_number",
-  "customs_tariff_number",
+  "cn_code",
   "column_break_jhfv",
   "good_description",
   "values_section",
@@ -125,14 +125,6 @@
    "fieldname": "article_number",
    "fieldtype": "Data",
    "label": "Article Number"
-  },
-  {
-   "fieldname": "customs_tariff_number",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Customs Tariff Number",
-   "non_negative": 1,
-   "reqd": 1
   },
   {
    "fieldname": "column_break_qjtl",
@@ -609,13 +601,22 @@
    "fieldname": "carbon_price_due",
    "fieldtype": "Data",
    "label": "Carbon price due"
+  },
+  {
+   "fieldname": "cn_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "CN Code",
+   "non_negative": 1,
+   "options": "CN Code",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-04 11:46:57.459785",
+ "modified": "2025-06-17 08:02:50.685210",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Good",

--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -18,6 +18,7 @@
   "column_break_qjtl",
   "internal_customs_import_number",
   "cn_code",
+  "customs_tariff_number",
   "column_break_jhfv",
   "good_description",
   "values_section",
@@ -610,13 +611,19 @@
    "non_negative": 1,
    "options": "CN Code",
    "reqd": 1
+  },
+  {
+   "fieldname": "customs_tariff_number",
+   "fieldtype": "Data",
+   "label": "Customs Tariff Number",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-17 08:02:50.685210",
+ "modified": "2025-06-17 12:11:15.599733",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Good",

--- a/cbam/cbam/doctype/standard_emission_value/standard_emission_value.json
+++ b/cbam/cbam/doctype/standard_emission_value/standard_emission_value.json
@@ -14,8 +14,9 @@
  "fields": [
   {
    "fieldname": "cn_code",
-   "fieldtype": "Data",
-   "label": "CN Code"
+   "fieldtype": "Link",
+   "label": "CN Code",
+   "options": "CN Code"
   },
   {
    "fieldname": "country",
@@ -39,7 +40,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-17 07:05:19.389356",
+ "modified": "2025-06-17 07:56:15.044833",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Standard Emission Value",

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.py
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.py
@@ -16,7 +16,7 @@ def get_columns():
 		{
 			"fieldname": "cn_number",
 			"fieldtype": "Data",
-			"label": "CN Number"
+			"label": "CN Code"
 		},
 		{
 			"fieldname": "article_number",
@@ -127,7 +127,7 @@ def get_data():
 		UNION ALL
 
 		SELECT 
-			g.customs_tariff_number AS cn_number,
+			g.cn_code AS cn_number,
 			g.article_number,
 			g.supplier_name AS supplier,
 			g.country_of_origin AS country,	
@@ -143,9 +143,9 @@ def get_data():
 			(g.raw_mass * e.emission_value * {ets_carbon_price}) AS standard_emission_cost
 		FROM `tabGood` g
 		LEFT JOIN `tabStandard Emission Value` e 
-			ON g.customs_tariff_number = e.cn_code AND g.country_of_origin = e.country
+			ON g.cn_code = e.cn_code AND g.country_of_origin = e.country
 		LEFT JOIN `tabCN Code Bench Mark` b 
-			ON b.cn_code = g.customs_tariff_number
+			ON b.cn_code = g.cn_code
 		{good_filter_clause}
 	""", as_dict=1)
 

--- a/cbam/cbam/web_form/complete_goods_data/complete_goods_data.json
+++ b/cbam/cbam/web_form/complete_goods_data/complete_goods_data.json
@@ -99,10 +99,10 @@
   },
   {
    "allow_read_on_all_link_options": 0,
-   "fieldname": "customs_tariff_number",
+   "fieldname": "cn_code",
    "fieldtype": "Data",
    "hidden": 0,
-   "label": "Customs tariff number",
+   "label": "CN Code",
    "max_length": 0,
    "max_value": 0,
    "precision": "",

--- a/cbam/patches.txt
+++ b/cbam/patches.txt
@@ -9,4 +9,4 @@ cbam.patches.v15_4_3.setup_cbam_rep_name
 cbam.patches.set_dup_commercial_cont_notification
 cbam.patches.v15_4_3.update_nav_bar_items
 cbam.patches.v15_4_3.copy_customs_tariff_to_cn_code
-
+cbam.patches.v15_4_3.create_cn_code

--- a/cbam/patches.txt
+++ b/cbam/patches.txt
@@ -8,4 +8,5 @@ cbam.patches.v15_4_3.setup_cbam_rep_name
 # Patches added in this section will be executed after doctypes are migrated
 cbam.patches.set_dup_commercial_cont_notification
 cbam.patches.v15_4_3.update_nav_bar_items
+cbam.patches.v15_4_3.copy_customs_tariff_to_cn_code
 

--- a/cbam/patches/v15_4_3/copy_customs_tariff_to_cn_code.py
+++ b/cbam/patches/v15_4_3/copy_customs_tariff_to_cn_code.py
@@ -1,0 +1,9 @@
+import frappe
+
+def execute():
+    if frappe.db.has_column("Good", "cn_code"):
+        frappe.db.sql("""
+            UPDATE `tabGood`
+            SET cn_code = customs_tariff_number
+            WHERE customs_tariff_number IS NOT NULL AND customs_tariff_number != ''
+        """)

--- a/cbam/patches/v15_4_3/create_cn_code.py
+++ b/cbam/patches/v15_4_3/create_cn_code.py
@@ -1,0 +1,39 @@
+import frappe
+
+def execute():
+    if frappe.db.table_exists("Good") and frappe.db.table_exists("CN Code"):
+        result = frappe.db.sql("""
+            SELECT DISTINCT customs_tariff_number
+            FROM `tabGood`
+            WHERE customs_tariff_number IS NOT NULL AND customs_tariff_number != ''
+        """, as_dict=True)
+
+        codes = [row.customs_tariff_number.strip() for row in result]
+        frappe.enqueue(
+            method=insert_cn_codes_in_background,
+            queue='default',
+            timeout=600,
+            codes=codes,
+            now=False
+        )
+        print(f"Queued background job to insert CN Codes ({len(codes)} total).")
+
+def insert_cn_codes_in_background(codes):
+    created = 0
+    skipped = 0
+
+    for code in codes:
+        if not (code.isdigit() and len(code) == 8):
+            skipped += 1
+            continue
+
+        if not frappe.db.exists("CN Code", {"cn_code": code}):
+            frappe.get_doc({
+                "doctype": "CN Code",
+                "cn_code": code
+            }).insert(ignore_permissions=True)
+            created += 1
+
+    frappe.log_error("cn_code_import_complete", {
+        "message": f"Inserted {created} CN Codes. Skipped {skipped} invalid entries."
+    })

--- a/cbam/templates/goods_partial.html
+++ b/cbam/templates/goods_partial.html
@@ -20,7 +20,7 @@
             />
             </span>
         <span class="level-item bold ">
-            <span class="inv-name" id="doc-name" data-doctype="DocType" data-name="{{doc.name}}" data-installation-name="{{doc.installation_name or ''}}" data-installation="{{doc.installation or ''}}" data-emission="{{doc.emission_data or ''}}" data-emission-name="{{doc.emission_name or ''}}" title="Sales Invoice" >{{doc.customs_tariff_number}}</span>
+            <span class="inv-name" id="doc-name" data-doctype="DocType" data-name="{{doc.name}}" data-installation-name="{{doc.installation_name or ''}}" data-installation="{{doc.installation or ''}}" data-emission="{{doc.emission_data or ''}}" data-emission-name="{{doc.emission_name or ''}}" title="Sales Invoice" >{{doc.cn_code}}</span>
         </span>
     </div>
     <div class="list-row-col list-subject level tc-container gd">
@@ -125,8 +125,8 @@
       </div>
 
       <div class="tc-field-cont field-cont">
-        <span class="field-label">{{_('Customs Tariff Number')}}</span>
-        <div class="field tc-field">{{_(doc.customs_tariff_number)}}</div>
+        <span class="field-label">{{_('CN Code')}}</span>
+        <div class="field tc-field">{{_(doc.cn_code)}}</div>
       </div>
 
 

--- a/cbam/www/emission_data_list/index.html
+++ b/cbam/www/emission_data_list/index.html
@@ -184,8 +184,8 @@
                       <td>{{doc.invoice_number or ""}}</td>
                       <td><strong>{{_('Hand over date')}}</strong></td>
                       <td>{{doc.hand_over_date or ""}}</td>
-                      <td><strong>{{_('Customs Tariff Number')}}</strong></td>
-                      <td>{{doc.customs_tariff_number or ""}}</td>
+                      <td><strong>{{_('CN Code')}}</strong></td>
+                      <td>{{doc.cn_code or ""}}</td>
                     </tr>
                    
                   
@@ -221,8 +221,8 @@
                 </div>
 
                 <div class="tc-field-cont field-cont">
-                  <span class="field-label">{{_('Customs Tariff Number')}}</span>
-                  <div class="field tc-field">{{doc.customs_tariff_number or ""}}</div>
+                  <span class="field-label">{{_('CN Code')}}</span>
+                  <div class="field tc-field">{{doc.cn_code or ""}}</div>
                 </div>
                 <div class="prt-field-cont field-cont field-res" style="align-self: flex-end;">
                   <div class="tc-field prt-field print-btn">

--- a/cbam/www/goods_list/body.html
+++ b/cbam/www/goods_list/body.html
@@ -233,8 +233,8 @@
             </div>
 
             <div class="tc-field-cont field-cont">
-              <span class="field-label">{{_('Customs Tariff Number')}}</span>
-              <div class="field tc-field">{{doc.customs_tariff_number}}</div>
+              <span class="field-label">{{_('CN Code')}}</span>
+              <div class="field tc-field">{{doc.cn_code}}</div>
             </div>
             <div class="prt-field-cont field-cont field-res" style="align-self: flex-end;">
               <div class="tc-field prt-field print-btn">

--- a/cbam/www/goods_list/index.html
+++ b/cbam/www/goods_list/index.html
@@ -136,7 +136,7 @@
                         />
                       </span>
                     <span class="level-item bold ">
-                      <span class="inv-name" id="doc-name" data-doctype="DocType" data-name="{{doc.name}}" data-installation-name="{{doc.installation_name or ''}}" data-installation="{{doc.installation or ''}}" data-emission="{{doc.emission_data or ''}}" data-emission-name="{{doc.emission_name or ''}}" title="Sales Invoice" >{{doc.customs_tariff_number}}</span>
+                      <span class="inv-name" id="doc-name" data-doctype="DocType" data-name="{{doc.name}}" data-installation-name="{{doc.installation_name or ''}}" data-installation="{{doc.installation or ''}}" data-emission="{{doc.emission_data or ''}}" data-emission-name="{{doc.emission_name or ''}}" title="Sales Invoice" >{{doc.cn_code}}</span>
                     </span>
                 </div>
                 <div class="list-row-col list-subject level tc-container gd">
@@ -241,8 +241,8 @@
                 </div>
 
                 <div class="tc-field-cont field-cont">
-                  <span class="field-label">{{_('Customs Tariff Number')}}</span>
-                  <div class="field tc-field">{{_(doc.customs_tariff_number)}}</div>
+                  <span class="field-label">{{_('CN Code')}}</span>
+                  <div class="field tc-field">{{_(doc.cn_code)}}</div>
                 </div>
 
 


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/issues/488

This PR introduces a new standardized system for managing CN Codes (Customs Tariff Numbers) in the CBAM platform.

### Key Changes:
- ✅ Created new DocType: `CN Code`
  - Allows only 8-digit numeric codes
  - Enforced validation to prevent typos and malformed entries

- ✅ Replaced existing free-text CN code fields with `Link` fields to the `CN Code` DocType.

- ✅ Field labels standardized to `CN-Code` across all affected DocTypes.
- ✅ Existing data migrated and validated:
  - Non-8-digit codes skipped
  - Unique, valid codes inserted into `CN Code` master.
  - All references updated to use the new `Link` field

- ✅ write patch to create CN Codes (Background job) from `Good` records. 

This ensures better data integrity, reduces human error, and unifies CN Code usage throughout the system.


