### PR TITLE
gallehr/cbam#490: Standardize "Country" Field as "Installation Country" Across CBAM Modules

### DIFF
--- a/cbam/cbam/doctype/external_good/external_good.json
+++ b/cbam/cbam/doctype/external_good/external_good.json
@@ -17,8 +17,7 @@
   "column_break_ltwo",
   "real_emissions_value",
   "carbon_price_due",
-  "shipping_country_name",
-  "country",
+  "installation_country",
   "declarant"
  ],
  "fields": [
@@ -81,11 +80,6 @@
    "label": "mass [kg]"
   },
   {
-   "fieldname": "country",
-   "fieldtype": "Data",
-   "label": "Shipping Country"
-  },
-  {
    "fieldname": "declarant",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -94,16 +88,16 @@
    "reqd": 1
   },
   {
-   "fieldname": "shipping_country_name",
+   "fieldname": "installation_country",
    "fieldtype": "Link",
-   "label": "Shipping Country Name",
+   "label": "Installation Country",
    "options": "Country"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-17 07:41:53.940516",
+ "modified": "2025-06-17 14:53:09.401593",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "External Good",

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.py
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.py
@@ -16,7 +16,8 @@ def get_columns():
 		{
 			"fieldname": "cn_number",
 			"fieldtype": "Data",
-			"label": "CN Code"
+			"label": "CN Code",
+			"width": 150	
 		},
 		{
 			"fieldname": "article_number",
@@ -26,17 +27,19 @@ def get_columns():
 		{
 			"fieldname": "supplier",
 			"fieldtype": "Data",
-			"label": "Supplier"
+			"label": "Supplier",
+            "width": 200
 		},
         {
-			"fieldname": "country",
+			"fieldname": "installation_country",
 			"fieldtype": "Data",
-			"label": "Country"
+			"label": "Installation Country"
 		},
 		{
 			"fieldname": "raw_mass",
 			"fieldtype": "Data",
-			"label": "Mass [kg]"
+			"label": "Mass [kg]",
+			"width": 150
 		},
 		{
 			"fieldname": "mass_per_article",
@@ -107,7 +110,7 @@ def get_data():
 			eg.cn_code AS cn_number,
 			eg.article_no AS article_number,
 			eg.supplier,
-			eg.shipping_country_name AS country,
+			eg.installation_country,
 			eg.raw_mass,
 			eg.mass_per_article,
 			eg.buying_price_per_mass AS buying_price,
@@ -120,7 +123,7 @@ def get_data():
 			(eg.raw_mass * e.emission_value * {ets_carbon_price}) AS standard_emission_cost
 		FROM `tabExternal Good` eg
 		LEFT JOIN `tabStandard Emission Value` e 
-			ON eg.cn_code = e.cn_code AND eg.shipping_country_name = e.country
+			ON eg.cn_code = e.cn_code AND eg.installation_country = e.country
 		LEFT JOIN `tabCN Code Bench Mark` b 
 			ON b.cn_code = eg.cn_code
 
@@ -130,7 +133,7 @@ def get_data():
 			g.cn_code AS cn_number,
 			g.article_number,
 			g.supplier_name AS supplier,
-			g.country_of_origin AS country,	
+			g.installation_country,	
 			g.raw_mass,
 			g.mass_per_article,
 			g.buying_price,
@@ -143,7 +146,7 @@ def get_data():
 			(g.raw_mass * e.emission_value * {ets_carbon_price}) AS standard_emission_cost
 		FROM `tabGood` g
 		LEFT JOIN `tabStandard Emission Value` e 
-			ON g.cn_code = e.cn_code AND g.country_of_origin = e.country
+			ON g.cn_code = e.cn_code AND g.installation_country = e.country
 		LEFT JOIN `tabCN Code Bench Mark` b 
 			ON b.cn_code = g.cn_code
 		{good_filter_clause}


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/issues/490

This PR standardizes the usage of the "Country" field across the CBAM system by aligning it with the newly defined source: "Installation Country".

### Key Changes:

- ✅ **Financial Evaluation Report**:
  - Renamed column label from "Country" to **"Installation Country"**
  - Report data now fetches `installation_country` from the linked `Good` record

- ✅ **External Good**:
  - Renamed field:  **"Shipping Country Name" → "Installation Country"**
  - Removed deprecated field:  **"Shipping Country"**

- ✅ **Standard Emission Value**:
  - "Country" field retained by name, but now uses the same field type/source as **"Installation Country"** in External Good
