### PR TITLE
gallehr/cbam#457: fixed naming position in operating company

### DIFF
--- a/cbam/www/operating_company/index.html
+++ b/cbam/www/operating_company/index.html
@@ -79,6 +79,12 @@
               <div class="container responsive-md" id="commerical" style="width: 100%">
                 
                 <div class="tc-field-cont field-cont">
+                  <span class="field-label">{{_('First Name')}}</span>
+                  <div class="field tc-field">{{doc.main_contact_employee_first_name or ""}}</div>
+                </div>
+
+                
+                <div class="tc-field-cont field-cont">
                   <span class="field-label">{{_('Last Name')}}</span>
                   <div class="field tc-field">{{doc.main_contact_employee_last_name or ""}}</div>
                 </div>
@@ -86,11 +92,6 @@
                 <div class="tc-field-cont field-cont">
                   <span class="field-label">{{_('Email')}}</span>
                   <div class="field tc-field">{{doc.main_contact_employee_email or ""}}</div>
-                </div>
-                
-                <div class="tc-field-cont field-cont">
-                  <span class="field-label">{{_('First Name')}}</span>
-                  <div class="field tc-field">{{doc.main_contact_employee_first_name or ""}}</div>
                 </div>
                 
                 <div class="tc-field-cont field-cont">
@@ -117,6 +118,11 @@
               <div class="container responsive-md" id="cbam_representive" style="width: 100%">
                 
                 <div class="tc-field-cont field-cont">
+                  <span class="field-label">{{_('First Name')}}</span>
+                  <div class="field tc-field">{{doc.cbam_representive_employee_first_name or ""}}</div>
+                </div>
+
+                <div class="tc-field-cont field-cont">
                   <span class="field-label">{{_('Last Name')}}</span>
                   <div class="field tc-field">{{doc.cbam_representive_last_name or ""}}</div>
                 </div>
@@ -124,11 +130,6 @@
                 <div class="tc-field-cont field-cont">
                   <span class="field-label">{{_('Email')}}</span>
                   <div class="field tc-field">{{doc.cbam_representive_employee_email or ""}}</div>
-                </div>
-                
-                <div class="tc-field-cont field-cont">
-                  <span class="field-label">{{_('First Name')}}</span>
-                  <div class="field tc-field">{{doc.cbam_representive_employee_first_name or ""}}</div>
                 </div>
                 
                 <div class="tc-field-cont field-cont">


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/issues/457

**Summary:**

fixed naming position in My operating company (web)


Before:

![image](https://github.com/user-attachments/assets/41e4b9a6-7503-469c-bc83-b1d1adb507a7)

After:

![image](https://github.com/user-attachments/assets/22ff5d33-9a74-4936-953a-56dcb1a2d463)

