### PR TITLE
external goods Calculation

### DIFF
--- a/cbam/cbam/doctype/external_good/external_good.js
+++ b/cbam/cbam/doctype/external_good/external_good.js
@@ -16,5 +16,27 @@ frappe.ui.form.on("External Good", {
         }
       });
     }
-  }
+  },
+  raw_mass: function (frm) {
+    calculate_quantity(frm);
+    calculate_mass_per_article(frm);
+  },
+  mass_per_article: function(frm) {
+    calculate_quantity(frm);
+  },
+  quantity_of_articles: function(frm) {
+    calculate_mass_per_article(frm);
+    },
 });
+
+function calculate_quantity(frm) {
+  if (frm.doc.raw_mass && frm.doc.mass_per_article) {
+    frm.set_value('quantity_of_articles', frm.doc.raw_mass / frm.doc.mass_per_article);
+  }
+}
+
+function calculate_mass_per_article(frm) {
+  if (frm.doc.raw_mass && frm.doc.quantity_of_articles) {
+    frm.set_value('mass_per_article', frm.doc.raw_mass / frm.doc.quantity_of_articles);
+  }
+}

--- a/cbam/cbam/doctype/external_good/external_good.json
+++ b/cbam/cbam/doctype/external_good/external_good.json
@@ -11,7 +11,9 @@
   "article_no",
   "supplier",
   "raw_mass",
+  "calculate",
   "mass_per_article",
+  "quantity_of_articles",
   "number_of_items",
   "buying_price_per_mass",
   "column_break_ltwo",
@@ -38,9 +40,11 @@
    "label": "Supplier"
   },
   {
+   "depends_on": "eval:doc.calculate == \"Quantity of Articles\" || doc.calculate == \"Mass Per Article [kg]\"",
    "fieldname": "mass_per_article",
-   "fieldtype": "Data",
-   "label": "mass per article [kg]"
+   "fieldtype": "Float",
+   "label": "Mass Per Article [kg]",
+   "read_only_depends_on": "eval:doc.calculate == \"Mass Per Article [kg]\""
   },
   {
    "fieldname": "column_break_ltwo",
@@ -76,8 +80,9 @@
   },
   {
    "fieldname": "raw_mass",
-   "fieldtype": "Data",
-   "label": "mass [kg]"
+   "fieldtype": "Float",
+   "label": "Raw Mass [kg]",
+   "reqd": 1
   },
   {
    "fieldname": "declarant",
@@ -92,12 +97,27 @@
    "fieldtype": "Link",
    "label": "Installation Country",
    "options": "Country"
+  },
+  {
+   "description": "Option to calculate <b>Article Quantity </b>or <b>Mass per Article</b>",
+   "fieldname": "calculate",
+   "fieldtype": "Select",
+   "label": "Calculate",
+   "options": "\nMass Per Article [kg]\nQuantity of Articles",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.calculate == \"Quantity of Articles\" || doc.calculate == \"Mass Per Article [kg]\"",
+   "fieldname": "quantity_of_articles",
+   "fieldtype": "Float",
+   "label": "Quantity of Articles",
+   "read_only_depends_on": "eval:doc.calculate == \"Quantity of Articles\""
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-17 14:53:09.401593",
+ "modified": "2025-06-19 08:46:30.637315",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "External Good",


### PR DESCRIPTION
Description: \
**Rename and update fields** 

* mass \[kg\] --\> Raw Mass \[kg\]
* mass per article \[kg\] --\> Mass per Article \[kg\]
* Number of items --\> Quantity of Articles
* Raw Mass \[kg\] is mandatory
- New select field(Calculate) is added with options "Quantity of Articles" & "Mass Per Article \[kg\]". - Initially, both fields are hidden if the option is selected to "Quantity of Articles" then "Mass Per Article \[kg\]" is read only and vice versa.

Issue: External good calculations#489

Screen shot & GIF:
![Peek 2025-06-18 10-48](https://github.com/user-attachments/assets/bb13ff3c-96d1-42cb-9049-7a2fc3fd2ada)
