### PR TITLE
gallehr/cbam#486: add Multi-Select Filters to Financial Evaluation Re…

### DIFF
--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.js
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.js
@@ -2,7 +2,54 @@
 // For license information, please see license.txt
 
 frappe.query_reports["Financial Evaluation"] = {
-	"filters": [
-
+	onload: function (report) {
+		const style = document.createElement('style');
+		style.innerHTML = `
+		  .dt-instance-1 .dt-cell__content--col-0 {
+			width: auto !important;
+		  }
+		`;
+		document.head.appendChild(style);
+	},	  
+	filters: [
+	  {
+		fieldname: "cn_code",
+		label: __("CN Code"),
+		fieldtype: "MultiSelectList",
+		get_data(txt) {
+		  return frappe.db.get_list("CN Code", {
+			fields: ["cn_code as value", "cn_code as description"],
+			filters: [["cn_code", "like", `%${txt}%`]],
+			limit: 20
+		  });
+		}
+	  },
+	  {
+		fieldname: "supplier",
+		label: __("Supplier"),
+		fieldtype: "MultiSelectList",
+		get_data(txt) {
+		  return frappe.db.get_list("Good", {
+			fields: ["supplier_name as value", "supplier_number as description"],
+			filters: [["supplier_name", "like", `%${txt}%`]],
+			distinct: true,
+			limit: 20
+		  });
+		}
+	  },
+	  {
+		fieldname: "article_number",
+		label: __("Article Number"),
+		fieldtype: "MultiSelectList",
+		get_data(txt) {
+		  return frappe.db.get_list("Good", {
+			fields: ["article_number as value" , "article_number as description"],
+			filters: [["article_number", "like", `%${txt}%`]],
+			distinct: true,
+			limit: 20
+		  });
+		}
+	  }
 	]
-};
+  };
+  

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.py
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.py
@@ -8,13 +8,13 @@ from collections import defaultdict
 
 def execute(filters=None):
     columns = get_columns()
-    data = get_data()
+    data = get_data(filters=filters)
     return columns, data, None
 
 def get_columns():
     columns =  [
 		{
-			"fieldname": "cn_number",
+			"fieldname": "cn_code",
 			"fieldtype": "Data",
 			"label": "CN Code",
 			"width": 150	
@@ -85,72 +85,101 @@ def get_columns():
              
     return columns
 
-def get_data():
-    
+def get_data(filters=None):
+    filters = filters or {}
+
     ets_carbon_price = frappe.db.get_value(
         "ETS Carbon Price",
         {"ets_price_type": "Actual"},
         "price",
         order_by="date desc"
     ) or 0
-    
+
     user = frappe.session.user
     declarants = get_declarant_for_user(user)
-    
-    # If user has Declarant restrictions
-    good_filter_clause = ""
+
+    where_clauses = []
+    where_clauses_eg = []
+
+
+    # Declarant restriction (only for Good)
     if declarants:
-        # Safely format for SQL IN clause
         declarant_list = ', '.join(f"'{d}'" for d in declarants)
-        good_filter_clause = f" where g.declarant in ({declarant_list})"
+        where_clauses.append(f"g.declarant IN ({declarant_list})")
+
+    # CN Code filter
+    if filters.get("cn_code"):
+        cn_code_list = ', '.join(f"'{c}'" for c in filters["cn_code"])
+        where_clauses.append(f"(g.cn_code IN ({cn_code_list}))")
+        where_clauses_eg.append(f"(eg.cn_code IN ({cn_code_list}))")
+
+    # Supplier filter
+    if filters.get("supplier"):
+        supplier_list = ', '.join(f"'{s}'" for s in filters["supplier"])
+        where_clauses.append(f"(g.supplier_name IN ({supplier_list}))")
+        where_clauses_eg.append(f"(eg.supplier IN ({supplier_list}))")
+
+	# Article Number filter
+    if filters.get("article_number"):
+        article_number_list = ', '.join(f"'{s}'" for s in filters["article_number"])
+        where_clauses.append(f"(g.article_number IN ({article_number_list}))")
+        where_clauses_eg.append(f"(eg.article_no IN ({article_number_list}))")
         
-    
+    where_sql = ""
+    if where_clauses:
+        where_sql = "WHERE " + " AND ".join(where_clauses)
+        
+    where_sql_eg = ""
+    if where_clauses_eg:
+        where_sql_eg = "WHERE " + " AND ".join(where_clauses_eg) if where_clauses_eg else ""
+        
     data = frappe.db.sql(f"""
-		SELECT 
-			eg.cn_code AS cn_number,
-			eg.article_no AS article_number,
-			eg.supplier,
-			eg.installation_country,
-			eg.raw_mass,
-			eg.mass_per_article,
-			eg.buying_price_per_mass AS buying_price,
-			eg.carbon_price_due,
-			eg.real_emissions_value AS real_emission_value,
-			e.emission_value AS standard_emission_value,
-			b.bench_mark,
-			{ets_carbon_price} AS ets_carbon_price,
-			(eg.raw_mass * eg.real_emissions_value * {ets_carbon_price}) AS real_emission_cost,
-			(eg.raw_mass * e.emission_value * {ets_carbon_price}) AS standard_emission_cost
-		FROM `tabExternal Good` eg
-		LEFT JOIN `tabStandard Emission Value` e 
-			ON eg.cn_code = e.cn_code AND eg.installation_country = e.country
-		LEFT JOIN `tabCN Code Bench Mark` b 
-			ON b.cn_code = eg.cn_code
+        SELECT 
+            eg.cn_code,
+            eg.article_no AS article_number,
+            eg.supplier,
+            eg.installation_country,
+            eg.raw_mass,
+            eg.mass_per_article,
+            eg.buying_price_per_mass AS buying_price,
+            eg.carbon_price_due,
+            eg.real_emissions_value AS real_emission_value,
+            e.emission_value AS standard_emission_value,
+            b.bench_mark,
+            {ets_carbon_price} AS ets_carbon_price,
+            (eg.raw_mass * eg.real_emissions_value * {ets_carbon_price}) AS real_emission_cost,
+            (eg.raw_mass * e.emission_value * {ets_carbon_price}) AS standard_emission_cost
+        FROM `tabExternal Good` eg
+        LEFT JOIN `tabStandard Emission Value` e 
+            ON eg.cn_code = e.cn_code AND eg.installation_country = e.country
+        LEFT JOIN `tabCN Code Bench Mark` b 
+            ON b.cn_code = eg.cn_code
+		{where_sql_eg}
+        
+        UNION ALL
 
-		UNION ALL
-
-		SELECT 
-			g.cn_code AS cn_number,
-			g.article_number,
-			g.supplier_name AS supplier,
-			g.installation_country,	
-			g.raw_mass,
-			g.mass_per_article,
-			g.buying_price,
-			g.carbon_price_due,
-			g.specific_direct_embedded_emissions AS real_emission_value,
-			e.emission_value AS standard_emission_value,
-			b.bench_mark,
-			{ets_carbon_price} AS ets_carbon_price,
-			(g.raw_mass * g.specific_direct_embedded_emissions * {ets_carbon_price}) AS real_emission_cost,
-			(g.raw_mass * e.emission_value * {ets_carbon_price}) AS standard_emission_cost
-		FROM `tabGood` g
-		LEFT JOIN `tabStandard Emission Value` e 
-			ON g.cn_code = e.cn_code AND g.installation_country = e.country
-		LEFT JOIN `tabCN Code Bench Mark` b 
-			ON b.cn_code = g.cn_code
-		{good_filter_clause}
-	""", as_dict=1)
+        SELECT 
+            g.cn_code,
+            g.article_number,
+            g.supplier_name AS supplier,
+            g.installation_country,	
+            g.raw_mass,
+            g.mass_per_article,
+            g.buying_price,
+            g.carbon_price_due,
+            g.specific_direct_embedded_emissions AS real_emission_value,
+            e.emission_value AS standard_emission_value,
+            b.bench_mark,
+            {ets_carbon_price} AS ets_carbon_price,
+            (g.raw_mass * g.specific_direct_embedded_emissions * {ets_carbon_price}) AS real_emission_cost,
+            (g.raw_mass * e.emission_value * {ets_carbon_price}) AS standard_emission_cost
+        FROM `tabGood` g
+        LEFT JOIN `tabStandard Emission Value` e 
+            ON g.cn_code = e.cn_code AND g.installation_country = e.country
+        LEFT JOIN `tabCN Code Bench Mark` b 
+            ON b.cn_code = g.cn_code
+        {where_sql}
+    """, as_dict=1)
 
     return data
 


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/486
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/436

**Summary:**

This update introduces enhanced filtering capabilities to the Financial Evaluation Report, allowing users to perform deeper analysis based on selected parameters.

**Key Changes:**

- Added Multi-Select filters for:
  - CN Code
  - Supplier
  - Article Number

- Filters applied to both `External Good` and `Good` data sources.
- Ensured consistent filtering logic across both datasets using unified SQL conditions.

![Jun-19-2025 12-48-33](https://github.com/user-attachments/assets/efc0df5f-fbd6-41c6-9cb8-6fe3f7461236)
