### PR TITLE
gallehr/cbam#457: fixed typo

### DIFF
--- a/cbam/www/operating_company/index.html
+++ b/cbam/www/operating_company/index.html
@@ -114,7 +114,7 @@
                 {% endif %}
               </div>
               
-              <h2>{{_('CBAM Representive Details')}}</h2>
+              <h2>{{_('CBAM Representative Details')}}</h2>
               <div class="container responsive-md" id="cbam_representive" style="width: 100%">
                 
                 <div class="tc-field-cont field-cont">


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/457

**Summary:**

Fix typo in "Representative" (CBAM rep misspellt)

![image](https://github.com/user-attachments/assets/4999555f-b3a1-4aed-921d-942dc1c206a4)
