### PR TITLE
gallehr/cbam#486: refector the fields

### DIFF
--- a/cbam/cbam/doctype/external_good/external_good.json
+++ b/cbam/cbam/doctype/external_good/external_good.json
@@ -16,7 +16,6 @@
   "mass_per_article",
   "buying_price_per_mass",
   "quantity_of_articles",
-  "number_of_items",
   "column_break_ltwo",
   "real_emissions_value",
   "carbon_price_due",
@@ -61,11 +60,6 @@
   {
    "fieldname": "column_break_ltwo",
    "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "number_of_items",
-   "fieldtype": "Data",
-   "label": "Number of Articles"
   },
   {
    "fieldname": "buying_price_per_mass",
@@ -125,11 +119,11 @@
   },
   {
    "fetch_from": "report_id.reporting_period",
+   "fetch_if_empty": 1,
    "fieldname": "reporting_period",
    "fieldtype": "Link",
    "label": "Reporting Period",
-   "options": "Customs Import",
-   "read_only": 1
+   "options": "Customs Import"
   },
   {
    "fetch_from": "report_id.importer",
@@ -197,7 +191,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-19 16:21:28.573621",
+ "modified": "2025-06-20 08:18:33.718976",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "External Good",

--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -145,6 +145,7 @@
    "label": "Imported into EU on"
   },
   {
+   "description": "Reporting Period",
    "fieldname": "internal_customs_import_number",
    "fieldtype": "Link",
    "label": "Internal Customs Import Number",
@@ -623,7 +624,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-17 12:11:15.599733",
+ "modified": "2025-06-20 07:25:13.795829",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Good",

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.js
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.js
@@ -49,6 +49,19 @@ frappe.query_reports["Financial Evaluation"] = {
 			limit: 20
 		  });
 		}
+	  },
+	  {
+		fieldname: "reporting_period",
+		label: __("Reporting Period"),
+		fieldtype: "MultiSelectList",
+		get_data(txt) {
+		  return frappe.db.get_list("Customs Import", {
+			fields: ["name as value" , "name as description"],
+			filters: [["name", "like", `%${txt}%`]],
+			distinct: true,
+			limit: 20
+		  });
+		}
 	  }
 	]
   };

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.py
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.py
@@ -61,7 +61,7 @@ def get_columns():
 			"fieldtype": "Data",
 			"label": "Standard Emission Value"
 		},
-{
+        {
 			"fieldname": "ets_carbon_price",
 			"fieldtype": "Data",
 			"label": "ETS Carbon Price"
@@ -124,7 +124,14 @@ def get_data(filters=None):
         article_number_list = ', '.join(f"'{s}'" for s in filters["article_number"])
         where_clauses.append(f"(g.article_number IN ({article_number_list}))")
         where_clauses_eg.append(f"(eg.article_no IN ({article_number_list}))")
-        
+    
+    # Reporting Period filter
+    if filters.get("reporting_period"):
+        reporting_period_list = ', '.join(f"'{s}'" for s in filters["reporting_period"])
+        where_clauses.append(f"(g.reporting_period IN ({reporting_period_list}))")
+        where_clauses_eg.append(f"(eg.reporting_period IN ({reporting_period_list}))")
+
+
     where_sql = ""
     if where_clauses:
         where_sql = "WHERE " + " AND ".join(where_clauses)
@@ -146,6 +153,7 @@ def get_data(filters=None):
             eg.real_emissions_value AS real_emission_value,
             e.emission_value AS standard_emission_value,
             b.bench_mark,
+            eg.reporting_period,
             {ets_carbon_price} AS ets_carbon_price,
             (eg.raw_mass * eg.real_emissions_value * {ets_carbon_price}) AS real_emission_cost,
             (eg.raw_mass * e.emission_value * {ets_carbon_price}) AS standard_emission_cost
@@ -170,6 +178,7 @@ def get_data(filters=None):
             g.specific_direct_embedded_emissions AS real_emission_value,
             e.emission_value AS standard_emission_value,
             b.bench_mark,
+            g.internal_customs_import_number as reporting_period,
             {ets_carbon_price} AS ets_carbon_price,
             (g.raw_mass * g.specific_direct_embedded_emissions * {ets_carbon_price}) AS real_emission_cost,
             (g.raw_mass * e.emission_value * {ets_carbon_price}) AS standard_emission_cost


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/486
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/475

**Summary:**

- Added a new filter for "Reporting Period" in the Financial Evaluation Report
- In Good, this maps to the field "Internal Customs Import Number", used as the reporting period => Added field description: "Reporting Period”
- In External Good, created a new Link field called "Reporting Period" to store the reference
- Removed obsolete field "Number of Articles" from External Good as it's replaced by "Quantity of Articles".
