### PR TITLE
financial evaluation report chart

### DIFF
--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.json
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.json
@@ -1,5 +1,6 @@
 {
- "add_total_row": 0,
+ "add_total_row": 1,
+ "add_translate_data": 0,
  "columns": [],
  "creation": "2025-05-28 13:21:27.116375",
  "disabled": 0,
@@ -9,7 +10,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2025-05-28 13:21:33.332748",
+ "modified": "2025-06-20 08:23:46.286828",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Financial Evaluation",

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.py
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, Your Company and contributors
+# Copyright (c) 2025, phamos GmbH and contributors
 # For license information, please see license.txt
 
 import frappe
@@ -7,9 +7,11 @@ from frappe.utils import flt, getdate
 from collections import defaultdict
 
 def execute(filters=None):
+    filters = filters or {}
     columns = get_columns()
-    data = get_data(filters=filters)
-    return columns, data, None
+    data = get_data(filters)
+    chart = get_chart(data)
+    return columns, data, None, chart
 
 def get_columns():
     columns =  [
@@ -192,3 +194,56 @@ def get_declarant_for_user(user):
         distinct=True
     )
     return [row.parent for row in result]  # List of declarant names
+
+
+def get_chart(data, filters=None):
+    if not data:
+        return {}
+
+    filters = filters or {}
+
+    def to_float(value):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    # Always group by article + supplier
+    real_emission_map = defaultdict(float)
+    standard_emission_map = defaultdict(float)
+
+    for row in data:
+        article = row.get("article_number") or "Unknown"
+        supplier = row.get("supplier") or "Unknown"
+
+        if filters.get("supplier") and filters.get("supplier").strip():
+            if supplier != filters.get("supplier").strip():
+                continue  # only include rows matching selected supplier
+
+        label = f"{article} ({supplier})"
+        real_emission_map[label] += to_float(row.get("real_emission_cost"))
+        standard_emission_map[label] += to_float(row.get("standard_emission_cost"))
+
+    labels = list(real_emission_map.keys())
+    real_values = [real_emission_map[label] for label in labels]
+    standard_values = [standard_emission_map[label] for label in labels]
+
+    return {
+        "type": "bar",
+        "data": {
+            "labels": labels,
+            "datasets": [
+                {
+                    "name": "Real Emission Cost",
+                    "values": real_values
+                },
+                {
+                    "name": "Standard Emission Cost",
+                    "values": standard_values
+                }
+            ]
+        },
+        "colors": ["#5e64ff", "#ff5858"]
+    }
+
+


### PR DESCRIPTION
**Description:**
-** Added Graph in "Financial Evaluation Report"**

- When a supplier is selected in the filter, all article numbers are displayed on the graph with the supplier's name.
- When the supplier and article_no filters are set, only that article is shown in the graph.
- When article_no is selected, then all the suppliers with the article matching number are shown on the graph.

Issue: Financial Evaluation Report chart (#436)
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/436

**Screenshot & GIF:**
![Peek 2025-06-20 11-25](https://github.com/user-attachments/assets/dfb6c338-67ad-4c3c-9979-314131f10a9c)
