### PR TITLE
gallehr/cbam#500: added Reporting Period table

### DIFF
--- a/cbam/cbam/doctype/cbam_factor/cbam_factor.json
+++ b/cbam/cbam/doctype/cbam_factor/cbam_factor.json
@@ -5,11 +5,13 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "naming_series",
   "year",
   "disable",
-  "naming_series",
   "column_break_kxkf",
-  "cbam_factor"
+  "cbam_factor",
+  "section_break_qmyh",
+  "reporting_period"
  ],
  "fields": [
   {
@@ -38,12 +40,22 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "Naming Series"
+  },
+  {
+   "fieldname": "section_break_qmyh",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "reporting_period",
+   "fieldtype": "Table",
+   "label": "Reporting Period",
+   "options": "Reporting Period"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-20 13:06:15.561143",
+ "modified": "2025-06-23 12:09:39.114659",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "CBAM Factor",

--- a/cbam/cbam/doctype/cn_code_bench_mark/cn_code_bench_mark.json
+++ b/cbam/cbam/doctype/cn_code_bench_mark/cn_code_bench_mark.json
@@ -8,10 +8,10 @@
  "field_order": [
   "naming_series",
   "cn_code",
-  "valid_from",
   "column_break_zmxu",
   "bench_mark",
-  "valid_upto"
+  "section_break_mnmo",
+  "reporting_period"
  ],
  "fields": [
   {
@@ -33,24 +33,24 @@
    "label": "Naming Series"
   },
   {
-   "fieldname": "valid_from",
-   "fieldtype": "Date",
-   "label": "Valid From"
-  },
-  {
    "fieldname": "column_break_zmxu",
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "valid_upto",
-   "fieldtype": "Date",
-   "label": "Valid Upto"
+   "fieldname": "section_break_mnmo",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "reporting_period",
+   "fieldtype": "Table",
+   "label": "Reporting Period",
+   "options": "Reporting Period"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-18 07:44:33.238307",
+ "modified": "2025-06-23 12:09:02.161705",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "CN Code Bench Mark",

--- a/cbam/cbam/doctype/cn_code_bench_mark_emission_value/cn_code_bench_mark_emission_value.js
+++ b/cbam/cbam/doctype/cn_code_bench_mark_emission_value/cn_code_bench_mark_emission_value.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, phamos GmbH and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("CN Code Bench Mark", {
+// frappe.ui.form.on("CN Code Bench Mark Emission Value", {
 // 	refresh(frm) {
 
 // 	},

--- a/cbam/cbam/doctype/cn_code_bench_mark_emission_value/cn_code_bench_mark_emission_value.json
+++ b/cbam/cbam/doctype/cn_code_bench_mark_emission_value/cn_code_bench_mark_emission_value.json
@@ -23,7 +23,7 @@
   {
    "fieldname": "bench_mark",
    "fieldtype": "Data",
-   "label": "Bench Mark"
+   "label": "Bench Mark Emission Value [tCO2/tproduct]"
   },
   {
    "default": "CN-BM-",
@@ -50,10 +50,10 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-23 12:09:02.161705",
+ "modified": "2025-06-23 12:36:59.786916",
  "modified_by": "Administrator",
  "module": "CBAM",
- "name": "CN Code Bench Mark",
+ "name": "CN Code Bench Mark Emission Value",
  "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [

--- a/cbam/cbam/doctype/cn_code_bench_mark_emission_value/cn_code_bench_mark_emission_value.py
+++ b/cbam/cbam/doctype/cn_code_bench_mark_emission_value/cn_code_bench_mark_emission_value.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class CNCodeBenchMark(Document):
+class CNCodeBenchMarkEmissionValue(Document):
 	pass

--- a/cbam/cbam/doctype/cn_code_bench_mark_emission_value/test_cn_code_bench_mark_emission_value.py
+++ b/cbam/cbam/doctype/cn_code_bench_mark_emission_value/test_cn_code_bench_mark_emission_value.py
@@ -5,5 +5,5 @@
 from frappe.tests.utils import FrappeTestCase
 
 
-class TestCNCodeBenchMark(FrappeTestCase):
+class TestCNCodeBenchMarkEmissionValue(FrappeTestCase):
 	pass

--- a/cbam/cbam/doctype/reporting_period/reporting_period.js
+++ b/cbam/cbam/doctype/reporting_period/reporting_period.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, phamos GmbH and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Reporting Period", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/cbam/cbam/doctype/reporting_period/reporting_period.json
+++ b/cbam/cbam/doctype/reporting_period/reporting_period.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-06-23 11:57:45.184498",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "from_date",
+  "to_date"
+ ],
+ "fields": [
+  {
+   "allow_in_quick_entry": 1,
+   "fieldname": "from_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "From Date"
+  },
+  {
+   "allow_in_quick_entry": 1,
+   "fieldname": "to_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "To Date"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-06-23 12:05:28.761261",
+ "modified_by": "Administrator",
+ "module": "CBAM",
+ "name": "Reporting Period",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/cbam/cbam/doctype/reporting_period/reporting_period.py
+++ b/cbam/cbam/doctype/reporting_period/reporting_period.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, phamos GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ReportingPeriod(Document):
+	pass

--- a/cbam/cbam/doctype/reporting_period/test_reporting_period.py
+++ b/cbam/cbam/doctype/reporting_period/test_reporting_period.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, phamos GmbH and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestReportingPeriod(FrappeTestCase):
+	pass

--- a/cbam/cbam/doctype/standard_emission_value/standard_emission_value.json
+++ b/cbam/cbam/doctype/standard_emission_value/standard_emission_value.json
@@ -9,7 +9,8 @@
   "naming_series",
   "cn_code",
   "country",
-  "emission_value"
+  "emission_value",
+  "reporting_period"
  ],
  "fields": [
   {
@@ -35,12 +36,20 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "Naming Series"
+  },
+  {
+   "allow_bulk_edit": 1,
+   "allow_in_quick_entry": 1,
+   "fieldname": "reporting_period",
+   "fieldtype": "Table",
+   "label": "Reporting Period",
+   "options": "Reporting Period"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-17 07:56:15.044833",
+ "modified": "2025-06-23 12:07:12.918282",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Standard Emission Value",

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.py
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.py
@@ -162,7 +162,7 @@ def get_data(filters=None):
         FROM `tabExternal Good` eg
         LEFT JOIN `tabStandard Emission Value` e 
             ON eg.cn_code = e.cn_code AND eg.installation_country = e.country
-        LEFT JOIN `tabCN Code Bench Mark` b 
+        LEFT JOIN `tabCN Code Bench Mark Emission Value` b 
             ON b.cn_code = eg.cn_code
 		{where_sql_eg}
         
@@ -187,7 +187,7 @@ def get_data(filters=None):
         FROM `tabGood` g
         LEFT JOIN `tabStandard Emission Value` e 
             ON g.cn_code = e.cn_code AND g.installation_country = e.country
-        LEFT JOIN `tabCN Code Bench Mark` b 
+        LEFT JOIN `tabCN Code Bench Mark Emission Value` b 
             ON b.cn_code = g.cn_code
         {where_sql}
     """, as_dict=1)


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/500
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/475

This PR introduces a new child table "Reporting Period" to the following parent Doctypes:

- Standard Emission Value
- CN Code Bench Mark
- CBAM Factor

Includes From Date and To Date fields to define each reporting period range.

