### PR TITLE
Gallehr/cbam#439: fix mandatory validation in emission pop up

### DIFF
--- a/cbam/www/installation_list/index.js
+++ b/cbam/www/installation_list/index.js
@@ -406,7 +406,7 @@ function executeJS() {
                     label: __("Emission Notes (Sent to Declarant When Submitting Goods)"),
                     fieldname: "emission_notes",
                     fieldtype: "Small Text",
-                    mandatory_depends_on: "eval:!doc.specific_direct_embedded_emissions",
+                    mandatory_depends_on: "eval:!doc.specific_direct_embedded_emissions || !doc.electricity_consumed",
                     description: __("Explanation mandatory if no emission data entered"),
                     default: docData ? docData.emission_notes : "",
                 },


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/issues/439

**Summary:**
Emission notes should be mandatory if either "specific Embedded Emissions" or "Electricity consumed" is 0

![Emission Pop-up](https://github.com/user-attachments/assets/e26d6239-a5c2-4f13-88db-aecb0e6d15fe)
