### PR TITLE
Restructure Installation extended view

### DIFF
--- a/cbam/templates/includes/footer/footer_links.html
+++ b/cbam/templates/includes/footer/footer_links.html
@@ -21,7 +21,7 @@
 		</div>
     
 	</div>
-  <div id="cookieConsentBanner" style="display: none; position: fixed; bottom: 0; background: #222; color: white; width: 95%; padding: 15px; text-align: center; z-index: 9999;">
+  <div id="cookieConsentBanner" style="display: none; position: fixed; bottom: 0; background: #222; color: white; padding: 15px; text-align: center; z-index: 9999;">
       We only use functional cookies to ensure that the website functions optimally from a technical point of view. No tracking takes place. If you visit this site, we assume that you agree to this conditions.
         <button onclick="acceptCookies()" style="margin-left: 10px;background-color: red;color: white;"><b>Accept</b></button>
     </div>
@@ -99,6 +99,20 @@
       document.getElementById('cookieConsentBanner').style.display = 'none';
     }
   });
+document.addEventListener('DOMContentLoaded', function () {
+  const search = window.location.search;
+  const path = window.location.pathname;
+  const banner = document.getElementById('cookieConsentBanner');
+
+  if (banner) {
+    if (search.includes("cmd=web_logout") || path.startsWith("/me")) {
+      banner.style.width = "65%";
+    } else {
+      banner.style.width = "95%";
+    }
+  }
+});
+
 </script>
 
 

--- a/cbam/templates/installation_partial.html
+++ b/cbam/templates/installation_partial.html
@@ -59,7 +59,6 @@
 		</div>
 	</div>
 	<div class="container info-container hidden">
-		<h2>{{_('Base information of installation')}}</h2>
 		<div class="container responsive-md" style="width: 100%">
 		<div class="tc-field-cont field-cont">
 			<span class="field-label">{{_('Name of the Installation')}}</span>
@@ -81,7 +80,6 @@
 			<span class="field tc-field">{{doc.country}}</span>
 		</div>
 		</div>
-		<h2>{{_('Emissions data tracking of the installation')}}</h2>
 		<div class="container responsive-md" style="width: 100%">
 		<div class="tc-field-cont field-cont">
 			<span class="field-label">{{_('Is the installation tracking emissions data?')}}</span>
@@ -104,7 +102,18 @@
 		</div>
 		{% endif %}
 		</div>
-		<h2>{{_('Emission Details')}}</h2>
+		<div class="d-flex justify-content-between align-items-center mb-3" style="width: 100%;">
+			<div style="width: 140px;"></div>
+
+			<h2 class="m-0 text-center flex-grow-1">{{ _('Emission Details') }}</h2>
+
+			<div>
+				<a href="#" class="btn btn-primary btn-sm primary-action ex-pay-link add-newemission" style="text-decoration: none; color: white;">
+					{{ _('Add New Emission') }}
+				</a>
+			</div>
+		</div>
+		
 		<div class="table-responsive" style="width: 100%;">
 		<table class="table" style="min-width: 134%;">
 			
@@ -143,11 +152,7 @@
 			</tr>
 			{%endfor%}
 		</table>
-		<button class="btn btn-primary btn-sm primary-action">
-			<span> 
-			<span><a href = "#" class="ex-pay-link add-newemission">{{_('Add New Emission')}}</a></span>
-			</span>
-		</button>
+		
 		</div>
 		
 		


### PR DESCRIPTION
**Description:**

- Removed two headings i-e: "Base Information of installation", "Emissions data tracking of the Installation".
- Added emission button that appears on the top and right-hand side of the table.
- The emission button remains visible when the site is opened in split-screen view.
- Also noticed that the cookie banner has size issue on other pages so adjust width accordingly.

**Issue: https**: //git.phamos.eu/gallehr/cbam/-/work_items/514
**parent Issue:** https://git.phamos.eu/gallehr/cbam/-/issues/427

**Screenshot:**

![image](https://github.com/user-attachments/assets/e184c86d-975b-4329-9896-01e71600ac56)
