### PR TITLE
Display of emission data in good in website

### DIFF
--- a/cbam/templates/goods_partial.html
+++ b/cbam/templates/goods_partial.html
@@ -185,7 +185,7 @@
 
         <div class="tc-field-cont field-cont">
             <span class="field-label">{{_('Specific (direct) embedded emissions [tCO2/t]')}}</span>
-            <div class="field tc-field">{{_(doc.direct_emission_data) or ""}}</div>
+            <div class="field tc-field">{{_(doc.specific_direct_embedded_emissions) or ""}}</div>
         </div>
 
         <div class="tc-field-cont field-cont">

--- a/cbam/www/goods_list/index.html
+++ b/cbam/www/goods_list/index.html
@@ -254,7 +254,7 @@
 
                 <div class="tc-field-cont field-cont">
                   <span class="field-label">{{_('Good Description')}}</span>
-                  <div class="field tc-field">{{_(doc.good_description)}}</div>
+                  <div class="field tc-field" style="height: auto !important; white-space: pre-wrap; overflow-wrap: break-word;">{{_(doc.good_description)}}</div>
                 </div>
 
 
@@ -301,7 +301,7 @@
 
                   <div class="tc-field-cont field-cont">
                       <span class="field-label">{{_('Specific (direct) embedded emissions [tCO2/t]')}}</span>
-                      <div class="field tc-field">{{_(doc.direct_emission_data) or ""}}</div>
+                      <div class="field tc-field">{{_(doc.specific_direct_embedded_emissions) or ""}}</div>
                   </div>
 
                   <div class="tc-field-cont field-cont">


### PR DESCRIPTION
Description:
* All fields in the extended good list view are populated if data is available.
* The field name "source_of_indirect_emission_factor" is updated in the doctype but not on the webpage.
* Good description field extends vertically with text.

Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/513
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/472

SCreenshot:
![image](https://github.com/user-attachments/assets/d408edba-7a68-4c58-ba81-d04fedacbeaf)
