### PR TITLE
gallehr/cbam#532: disable auto login after reset password

### DIFF
--- a/cbam/hooks.py
+++ b/cbam/hooks.py
@@ -6,7 +6,7 @@ app_email = "wolfram.schmidt@phamos.eu"
 app_license = "mit"
 
 after_install = "cbam.utils.after_install.after_install"
-#update boot context
+#update boot context 
 boot_session = "cbam.boot.update_boot_context"
 extend_bootinfo = "cbam.boot.update_website_context"
 website_context = {
@@ -199,9 +199,9 @@ scheduler_events = {
 # Overriding Methods
 # ------------------------------
 #
-# override_whitelisted_methods = {
-# 	"frappe.desk.doctype.event.event.get_events": "cbam.event.get_events"
-# }
+override_whitelisted_methods = {
+	"frappe.core.doctype.user.user.update_password": "cbam.override.user.update_password"
+}
 #
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,

--- a/cbam/override/user.py
+++ b/cbam/override/user.py
@@ -1,0 +1,62 @@
+from frappe.apps import get_default_path
+from frappe.auth import MAX_PASSWORD_SIZE
+from frappe.core.doctype.user.user import _get_user_for_update_password, handle_password_test_fail, reset_user_data, test_password_strength
+from frappe.utils.password import update_password as _update_password, check_password
+from frappe.utils import today
+import frappe
+from frappe.utils.data import sha256_hash, now_datetime
+from datetime import timedelta
+from frappe import _
+from frappe.utils import cint
+from frappe.website.utils import get_home_page
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def update_password(
+	new_password: str, logout_all_sessions: int = 0, key: str | None = None, old_password: str | None = None
+):
+	frappe.log_error("update password working!")
+	"""Update password for the current user.
+
+	Args:
+	        new_password (str): New password.
+	        logout_all_sessions (int, optional): If set to 1, all other sessions will be logged out. Defaults to 0.
+	        key (str, optional): Password reset key. Defaults to None.
+	        old_password (str, optional): Old password. Defaults to None.
+	"""
+
+	if len(new_password) > MAX_PASSWORD_SIZE:
+		frappe.throw(_("Password size exceeded the maximum allowed size."))
+
+	result = test_password_strength(new_password)
+	feedback = result.get("feedback", None)
+
+	if feedback and not feedback.get("password_policy_validation_passed", False):
+		handle_password_test_fail(feedback)
+
+	res = _get_user_for_update_password(key, old_password)
+	if res.get("message"):
+		frappe.local.response.http_status_code = 410
+		return res["message"]
+	else:
+		user = res["user"]
+
+	logout_all_sessions = cint(logout_all_sessions) or frappe.db.get_single_value(
+		"System Settings", "logout_on_password_reset"
+	)
+	_update_password(user, new_password, logout_all_sessions=cint(logout_all_sessions))
+
+	user_doc, redirect_url = reset_user_data(user)
+
+	user_doc.validate_reset_password()
+
+    # ❌ Do NOT auto-login
+
+	# frappe.local.login_manager.login_as(user)
+
+	frappe.db.set_value("User", user, "last_password_reset_date", today())
+	frappe.db.set_value("User", user, "reset_password_key", "")
+
+    # Return success message instead of redirect
+	frappe.msgprint(_("Your password has been updated. Please log in manually."))
+	return "/login"


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/532
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/450

**Summary:**

**Prevent Auto-Login After Password Reset via Email**

**📝 Description:**

❓ Problem

By default, when a user resets their password using the reset link sent via email, Frappe automatically logs them in.
This behavior poses a security concern in some cases, especially when password reset links are exposed via compromised email accounts.


**✅ Solution**

Override the Frappe core method frappe.core.doctype.user.user.update_password to disable automatic login after password reset via email.
