### PR TITLE
Gallehr/cbam#536: Enhance Toggle Functionality in Financial Evaluation Report.

### DIFF
--- a/cbam/cbam/page/financial_evaluation_report/chart.js
+++ b/cbam/cbam/page/financial_evaluation_report/chart.js
@@ -1,0 +1,106 @@
+frappe.provide('cbam')
+
+
+// Helper: Get chart data, optionally per tonne
+cbam.get_chart_data = function get_chart_data(data, per_tonne = false) {
+    const labels = [];
+    const actual_costs = [];
+    const standard_costs = [];
+    if (!data) return { labels: [], actual_costs: [], standard_costs: [] };
+    data.forEach(row => {
+        const article = row.article_number || '';
+        const supplier = row.supplier || '';
+        labels.push(`${article} (${supplier})`);
+        let mass = Number(row.raw_mass) || 0;
+        let actual = Number(row.real_emission_cost) || 0;
+        let standard = Number(row.standard_emission_cost) || 0;
+        if (per_tonne && mass > 0) {
+            let mass_tonnes = mass / 1000;
+            actual = actual / mass_tonnes;
+            standard = standard / mass_tonnes;
+        }
+        actual_costs.push(actual);
+        standard_costs.push(standard);
+    });
+    return {
+        labels,
+        actual_costs,
+        standard_costs
+    };
+}
+
+
+cbam.update_chart = function update_chart(chart_data) {
+    $('#chart-section').empty();
+
+    if (!chart_data || !chart_data.labels || chart_data.labels.length === 0) {
+        $('#chart-section').html('<div class="text-center text-muted p-4">No data available for chart</div>');
+        return;
+    }
+
+    // Custom: Concatenate article and supplier for x-axis labels if available
+    let labels = chart_data.labels;
+    let label_map = {};
+    if (chart_data.articles && chart_data.suppliers && Array.isArray(chart_data.articles) && Array.isArray(chart_data.suppliers)) {
+        labels = chart_data.articles.map((article, idx) => {
+            const supplier = chart_data.suppliers[idx] || '';
+            const label = `${article} (${supplier})`;
+            label_map[idx] = label;
+            return label;
+        });
+    } else {
+        labels = chart_data.labels;
+        labels.forEach((l, idx) => { label_map[idx] = l; });
+    }
+
+    // Highcharts integration: create a scrollable container and chart div
+    const minWidth = Math.max(600, labels.length * 80); // 80px per label as a heuristic
+    $('#chart-section').append('<div id="highchart-scroll-inner" style="overflow-x: auto; width: 100%;"><div id="highchart-bar" style="min-width: ' + minWidth + 'px; max-height: 350px;"></div></div>');
+
+    function renderHighChart() {
+        Highcharts.chart('highchart-bar', {
+            chart: {
+                type: 'column',
+                height: 350
+            },
+            credits: {
+                enabled: false
+            },
+            title: { text: __('Standard vs Actual Cost') },
+            xAxis: {
+                categories: labels,
+                labels: {
+                    rotation: 45,
+                    style: { fontSize: '12px' }
+                }
+            },
+            yAxis: {
+                min: 0,
+                title: { text: __('Cost') }
+            },
+            legend: { align: 'center', verticalAlign: 'bottom', layout: 'horizontal' },
+            series: [
+                {
+                    name: __('Actual Cost'),
+                    data: chart_data.actual_costs,
+                    color: '#3b5bdb'
+                },
+                {
+                    name: __('Standard Cost'),
+                    data: chart_data.standard_costs,
+                    color: '#fa5252'
+                }
+            ]
+        });
+    }
+
+    if (typeof window.Highcharts === 'undefined') {
+        // Dynamically load Highcharts from CDN if not already loaded
+        const script = document.createElement('script');
+        script.src = 'https://code.highcharts.com/highcharts.js';
+        script.onload = () => renderHighChart();
+        document.head.appendChild(script);
+    } else {
+        renderHighChart();
+    }
+}

--- a/cbam/cbam/page/financial_evaluation_report/filter.js
+++ b/cbam/cbam/page/financial_evaluation_report/filter.js
@@ -1,0 +1,129 @@
+frappe.provide('cbam');
+
+/**
+ * Create a filter control and append to the parent selector.
+ */
+cbam.create_filter = function(label, fieldtype, fieldname, parentSelector, options = null, link_to = null, default_val = null) {
+    const df = { label, fieldname, fieldtype, options, default: default_val };
+    if (link_to) df.options = link_to;
+    const control = frappe.ui.form.make_control({ parent: $('<div class="col mb-2"></div>').appendTo(parentSelector), df });
+    control.refresh();
+    if (default_val !== undefined && default_val !== null && default_val !== "") {
+        control.set_value(default_val);
+    }
+    return control;
+};
+
+/**
+ * Setup clear buttons for filter groups.
+ */
+cbam.setup_filter_clear_buttons = function(filters, load_report_table) {
+    $('#clear-group-1').on('click', () => {
+        ['cn_code', 'supplier', 'article_number', 'reporting_period'].forEach(key => {
+            filters[key]?.set_value([]);
+        });
+        load_report_table(true);
+    });
+    $('#clear-group-2').on('click', () => {
+        ['ets_price_type', 'year', 'month', 'ets_price'].forEach(key => {
+            if (filters[key]) {
+                if (filters[key].df.fieldtype === 'MultiSelectList') {
+                    filters[key].set_value([]);
+                } else {
+                    filters[key].set_value(null);
+                }
+            }
+        });
+        load_report_table(true);
+    });
+};
+
+/**
+ * Setup listeners for filter changes.
+ */
+cbam.setup_filter_listeners = function(filters, load_report_table, update_stat_card_values, refresh_ets_price_options) {
+    ['cn_code', 'supplier', 'article_number', 'reporting_period'].forEach(key => {
+        const ctrl = filters[key];
+        if (ctrl) {
+            ctrl.df.onchange = () => {
+                load_report_table(true);
+            };
+        }
+    });
+    ['ets_price_type', 'year', 'month', 'ets_price'].forEach(key => {
+        const ctrl = filters[key];
+        if (ctrl) {
+            ctrl.df.onchange = () => {
+                const selected_filters = {
+                    ets_price_type: filters.ets_price_type.get_value(),
+                    year: filters.year.get_value(),
+                    ets_price: filters.ets_price.get_value(),
+                };
+                update_stat_card_values(key, selected_filters);
+                if (key === 'ets_price_type' || key === 'year') {
+                    cbam.refresh_ets_price_options(
+                        filters.ets_price_type.get_value(),
+                        filters.year.get_value()
+                    );
+                }
+                load_report_table(true);
+            };
+        }
+    });
+};
+
+/**
+ * Utility to collect all selected filters and stat values from the DOM.
+ */
+cbam.get_all_selected_filters = function(filters) {
+    const selected_filters = {};
+            ['cn_code', 'supplier', 'article_number', 'reporting_period'].forEach(key => {
+                selected_filters[key] = filters[key]?.get_value?.() || [];
+            });
+            ['ets_price_type', 'year', 'ets_price'].forEach(key => {
+                selected_filters[key] = filters[key]?.get_value?.() || '';
+            });
+            selected_filters.cbam_factor = parseFloat($('[data-stat="cbam-factor"]').text()) || 0;
+            selected_filters.bench_mark = parseFloat($('[data-stat="bench-mark-emission-value"]').text()) || 0;
+            selected_filters.emission_value = parseFloat($('[data-stat="standard-emission-value"]').text()) || 0;
+            selected_filters.ets_price_value = parseFloat($('[data-stat="ets-price"]').text()) || 0;
+            return selected_filters;
+};
+
+/**
+ * Refresh ETS Price options based on type and year.
+ */
+cbam.refresh_ets_price_options = function(filters, ets_price_type, year) {
+    if (!ets_price_type || !year) return;
+            frappe.db.get_list('ETS Carbon Price', {
+                fields: ['name', 'price', 'price_date'],
+                filters: { ets_price_type },
+                order_by: 'price_date desc',
+                limit: 100,
+            }).then(res => {
+                const prices = res
+                    .filter(row => {
+                        const y = frappe.datetime.str_to_obj(row.price_date).getFullYear();
+                        return y == year;
+                    })
+                    .map(row => {
+                        let dateStr = '';
+                        if (row.price_date) {
+                            const d = frappe.datetime.str_to_obj(row.price_date);
+                            dateStr = ` (${d.getDate().toString().padStart(2, '0')}-${(d.getMonth()+1).toString().padStart(2, '0')}-${d.getFullYear()})`;
+                        }
+                        return {
+                            label: `${row.price}${dateStr}`,
+                            value: String(row.price)
+                        };
+                    });
+                filters.ets_price.df.options = prices;
+                filters.ets_price.refresh();
+                if (prices.length) {
+                    filters.ets_price.set_value(prices[0].value);
+                }
+            }).catch(() => {
+                filters.ets_price.df.options = [];
+                filters.ets_price.refresh();
+            });
+};

--- a/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.js
+++ b/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.js
@@ -22,8 +22,8 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
 
         // Filters
         const filters = setup_filters();
-        setup_filter_clear_buttons(filters);
-        setup_filter_listeners(filters);
+        cbam.setup_filter_clear_buttons(filters, load_report_table);
+        cbam.setup_filter_listeners(filters, load_report_table, update_stat_card_values, (ets_price_type, year) => cbam.refresh_ets_price_options(filters, ets_price_type, year));
 
         // Pagination state
         let start = 0;
@@ -179,134 +179,79 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
          */
         function setup_filters() {
             const currentYear = frappe.datetime.get_today().split('-')[0];
-            return {
-                cn_code: create_filter('CN Code', 'MultiSelectList', 'cn_code', '#filter-section-group-1'),
-                supplier: create_filter('Supplier', 'MultiSelectList', 'supplier', '#filter-section-group-1'),
-                article_number: create_filter('Article Number', 'MultiSelectList', 'article_number', '#filter-section-group-1'),
-                reporting_period: create_filter('Reporting Period', 'MultiSelectList', 'reporting_period', '#filter-section-group-1'),
-                year: create_filter('Year', 'Link', 'year', '#filter-section-group-2', null, 'Year', currentYear),
-                ets_price_type: create_filter('ETS Price Type', 'Select', 'ets_price_type', '#filter-section-group-2', ['', 'Actual', 'Prediction'], null, 'Actual'),
-                ets_price: create_filter('ETS Price', 'Select', 'ets_price', '#filter-section-group-2'),
+            const filters = {
+                cn_code: cbam.create_filter('CN Code', 'MultiSelectList', 'cn_code', '#filter-section-group-1', []),
+                supplier: cbam.create_filter('Supplier', 'MultiSelectList', 'supplier', '#filter-section-group-1', []),
+                article_number: cbam.create_filter('Article Number', 'MultiSelectList', 'article_number', '#filter-section-group-1', []),
+                reporting_period: cbam.create_filter('Reporting Period', 'MultiSelectList', 'reporting_period', '#filter-section-group-1', []),
+                year: cbam.create_filter('Year', 'Link', 'year', '#filter-section-group-2', null, 'Year', currentYear),
+                ets_price_type: cbam.create_filter('ETS Price Type', 'Select', 'ets_price_type', '#filter-section-group-2', ['', 'Actual', 'Prediction'], null, 'Actual'),
+                ets_price: cbam.create_filter('ETS Price', 'Select', 'ets_price', '#filter-section-group-2', []),
             };
-        }
 
-        /**
-         * Setup clear buttons for filter groups.
-         * @param {Object} filters
-         */
-        function setup_filter_clear_buttons(filters) {
-            $('#clear-group-1').on('click', () => {
-                ['cn_code', 'supplier', 'article_number', 'reporting_period'].forEach(key => {
-                    filters[key]?.set_value([]);
+            // CN Code: no dependencies
+            filters.cn_code.df.get_data = function(txt) {
+                return frappe.db.get_list('CN Code', {
+                    fields: ['cn_code as value', 'cn_code as description'],
+                    filters: [['cn_code', 'like', `%${txt}%`]],
+                    limit: 20,
                 });
-                load_report_table(true);
-            });
-            $('#clear-group-2').on('click', () => {
-                ['ets_price_type', 'year', 'month', 'ets_price'].forEach(key => {
-                    if (filters[key]) {
-                        if (filters[key].df.fieldtype === 'MultiSelectList') {
-                            filters[key].set_value([]);
-                        } else {
-                            filters[key].set_value(null);
-                        }
-                    }
+            };
+
+            // Supplier: depends on selected CN Code(s)
+            filters.supplier.df.get_data = function(txt) {
+                const cn_code_vals = filters.cn_code?.get_value?.() || [];
+                let filterArr = [['supplier', 'like', `%${txt}%`]];
+                if (cn_code_vals.length) {
+                    filterArr.push(['cn_code', 'in', cn_code_vals]);
+                }
+                return frappe.db.get_list('External Good', {
+                    fields: ['supplier as value', 'supplier as description'],
+                    filters: filterArr,
+                    distinct: true,
+                    limit: 20,
                 });
-                load_report_table(true);
-            });
-        }
+            };
 
-        /**
-         * Setup listeners for filter changes.
-         * @param {Object} filters
-         */
-        function setup_filter_listeners(filters) {
-            ['cn_code', 'supplier', 'article_number', 'reporting_period'].forEach(key => {
-                const ctrl = filters[key];
-                if (ctrl) {
-                    ctrl.df.onchange = () => {
-                        load_report_table(true);
-                    };
+            // Article Number: depends on selected Supplier(s) and CN Code(s)
+            filters.article_number.df.get_data = function(txt) {
+                const supplier_vals = filters.supplier?.get_value?.() || [];
+                const cn_code_vals = filters.cn_code?.get_value?.() || [];
+                let filterArr = [['article_no', 'like', `%${txt}%`]];
+                if (supplier_vals.length) {
+                    filterArr.push(['supplier', 'in', supplier_vals]);
                 }
-            });
-            ['ets_price_type', 'year', 'month', 'ets_price'].forEach(key => {
-                const ctrl = filters[key];
-                if (ctrl) {
-                    ctrl.df.onchange = () => {
-                        const selected_filters = {
-                            ets_price_type: filters.ets_price_type.get_value(),
-                            year: filters.year.get_value(),
-                            ets_price: filters.ets_price.get_value(),
-                        };
-                        update_stat_card_values(key, selected_filters);
-                        if (key === 'ets_price_type' || key === 'year') {
-                            refresh_ets_price_options(
-                                filters.ets_price_type.get_value(),
-                                filters.year.get_value()
-                            );
-                        }
-                        load_report_table(true);
-                    };
+                if (cn_code_vals.length) {
+                    filterArr.push(['cn_code', 'in', cn_code_vals]);
                 }
-            });
-        }
+                return frappe.db.get_list('External Good', {
+                    fields: ['article_no as value', 'article_no as description'],
+                    filters: filterArr,
+                    distinct: true,
+                    limit: 20,
+                });
+            };
 
-        /**
-         * Collect all selected filters and stat values from the DOM.
-         * @returns {Object}
-         */
-        function get_all_selected_filters() {
-            const selected_filters = {};
-            ['cn_code', 'supplier', 'article_number', 'reporting_period'].forEach(key => {
-                selected_filters[key] = filters[key]?.get_value?.() || [];
-            });
-            ['ets_price_type', 'year', 'ets_price'].forEach(key => {
-                selected_filters[key] = filters[key]?.get_value?.() || '';
-            });
-            selected_filters.cbam_factor = parseFloat($('[data-stat="cbam-factor"]').text()) || 0;
-            selected_filters.bench_mark = parseFloat($('[data-stat="bench-mark-emission-value"]').text()) || 0;
-            selected_filters.emission_value = parseFloat($('[data-stat="standard-emission-value"]').text()) || 0;
-            selected_filters.ets_price_value = parseFloat($('[data-stat="ets-price"]').text()) || 0;
-            return selected_filters;
-        }
-
-        /**
-         * Refresh ETS Price options based on type and year.
-         * @param {string} ets_price_type
-         * @param {string|number} year
-         */
-        function refresh_ets_price_options(ets_price_type, year) {
-            if (!ets_price_type || !year) return;
-            frappe.db.get_list('ETS Carbon Price', {
-                fields: ['name', 'price', 'price_date'],
-                filters: { ets_price_type },
-                order_by: 'price_date desc',
-                limit: 100,
-            }).then(res => {
-                const prices = res
-                    .filter(row => {
-                        const y = frappe.datetime.str_to_obj(row.price_date).getFullYear();
-                        return y == year;
-                    })
-                    .map(row => {
-                        let dateStr = '';
-                        if (row.price_date) {
-                            const d = frappe.datetime.str_to_obj(row.price_date);
-                            dateStr = ` (${d.getDate().toString().padStart(2, '0')}-${(d.getMonth()+1).toString().padStart(2, '0')}-${d.getFullYear()})`;
-                        }
-                        return {
-                            label: `${row.price}${dateStr}`,
-                            value: String(row.price)
-                        };
-                    });
-                filters.ets_price.df.options = prices;
-                filters.ets_price.refresh();
-                if (prices.length) {
-                    filters.ets_price.set_value(prices[0].value);
+            // Reporting Period: depends on selected Supplier(s) and CN Code(s)
+            filters.reporting_period.df.get_data = function(txt) {
+                const supplier_vals = filters.supplier?.get_value?.() || [];
+                const cn_code_vals = filters.cn_code?.get_value?.() || [];
+                let filterArr = [['reporting_period', 'like', `%${txt}%`]];
+                if (supplier_vals.length) {
+                    filterArr.push(['supplier', 'in', supplier_vals]);
                 }
-            }).catch(() => {
-                filters.ets_price.df.options = [];
-                filters.ets_price.refresh();
-            });
+                if (cn_code_vals.length) {
+                    filterArr.push(['cn_code', 'in', cn_code_vals]);
+                }
+                return frappe.db.get_list('External Good', {
+                    fields: ['reporting_period as value', 'reporting_period as description'],
+                    filters: filterArr,
+                    distinct: true,
+                    limit: 20,
+                });
+            };
+
+            return filters;
         }
 
         /**
@@ -343,75 +288,6 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
         }
 
         /**
-         * Create a filter control and append to the parent selector.
-         * @param {string} label
-         * @param {string} fieldtype
-         * @param {string} fieldname
-         * @param {string} parentSelector
-         * @param {Array|null} options
-         * @param {string|null} link_to
-         * @param {string|null} default_val
-         * @returns {Object}
-         */
-        function create_filter(label, fieldtype, fieldname, parentSelector, options = null, link_to = null, default_val = null) {
-            const df = { label, fieldname, fieldtype, options, default: default_val };
-            if (link_to) df.options = link_to;
-            if (fieldtype === 'MultiSelectList') {
-                df.get_data = function (txt) {
-                    const supplier_vals = filters.supplier?.get_value?.() || [];
-                    const cn_code_vals = filters.cn_code?.get_value?.() || [];
-                    if (fieldname === 'article_number') {
-                        return frappe.db.get_list('External Good', {
-                            fields: ['article_no as value', 'article_no as description'],
-                            filters: [
-                                ['article_no', 'like', `%${txt}%`],
-                                supplier_vals.length ? ['supplier', 'in', supplier_vals] : null,
-                                cn_code_vals.length ? ['cn_code', 'in', cn_code_vals] : null,
-                            ].filter(Boolean),
-                            distinct: true,
-                            limit: 20,
-                        });
-                    }
-                    if (fieldname === 'reporting_period') {
-                        return frappe.db.get_list('External Good', {
-                            fields: ['reporting_period as value', 'reporting_period as description'],
-                            filters: [
-                                ['name', 'like', `%${txt}%`],
-                                supplier_vals.length ? ['supplier', 'in', supplier_vals] : null,
-                                cn_code_vals.length ? ['cn_code', 'in', cn_code_vals] : null,
-                            ].filter(Boolean),
-                            distinct: true,
-                            limit: 20,
-                        });
-                    }
-                    if (fieldname === 'cn_code') {
-                        return frappe.db.get_list('CN Code', {
-                            fields: ['cn_code as value', 'cn_code as description'],
-                            filters: [['cn_code', 'like', `%${txt}%`]],
-                            limit: 20,
-                        });
-                    }
-                    if (fieldname === 'supplier') {
-                        return frappe.db.get_list('External Good', {
-                            fields: ['supplier as value', 'supplier as description'],
-                            filters: [['supplier', 'like', `%${txt}%`]],
-                            distinct: true,
-                            limit: 20,
-                        });
-                    }
-                };
-            }
-            const $col = $('<div class="col mb-2"></div>').appendTo(parentSelector);
-            const control = frappe.ui.form.make_control({ parent: $col, df });
-            control.refresh();
-            // Set default value in UI if provided
-            if (default_val !== undefined && default_val !== null && default_val !== "") {
-                control.set_value(default_val);
-            }
-            return control;
-        }
-
-        /**
          * Clear and render stat cards with default values.
          */
         function clear_stats() {
@@ -428,14 +304,12 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
             });
         }
 
-
-
         /**
          * Load and render the report table and update chart.
          * @param {boolean} reset If true, reset table and start from first page.
          * @param {Object} [filters={}]
          */
-        function load_report_table(reset = false, filters = {}) {
+        function load_report_table(reset = false, filters_arg = {}) {
             if (reset) {
                 start = 0;
                 all_data = [];
@@ -444,10 +318,10 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
                     datatable = null;
                 }
             }
-            const selected_filters = get_all_selected_filters();
+            const selected_filters = cbam.get_all_selected_filters(filters);
             frappe.call({
                 method: 'cbam.cbam.page.financial_evaluation_report.financial_evaluation_report.get_report_data',
-                args: { filters, selected_filters, start, page_length },
+                args: { filters: filters_arg, selected_filters, start, page_length },
                 callback: function (r) {
                     if (r.message) {
                         const { columns, data, chart_data, total_count: count } = r.message;

--- a/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.js
+++ b/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.js
@@ -40,6 +40,66 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
         // Setup table toggle functionality
         setup_table_toggle();
 
+        // --- Show Selected Rows Toggle Logic ---
+        function get_selected_rows_data() {
+            if (!datatable) return [];
+            const selectedIndexes = datatable.rowmanager.getCheckedRows();
+            return selectedIndexes.map(idx => all_data[idx]);
+        }
+
+        // Listen for toggle event
+        $('#selected-rows-toggle').on('change', function() {
+            const showSelected = $(this).is(':checked');
+            let chart_data;
+            if (showSelected) {
+                const selectedData = get_selected_rows_data();
+                chart_data = get_chart_data(selectedData);
+            } else {
+                chart_data = get_chart_data(all_data);
+            }
+            update_chart(chart_data);
+        });
+
+		function get_chart_data(data) {
+			// data: array of row objects
+			const labels = [];
+			const actual_costs = [];
+			const standard_costs = [];
+			if (!data) return { labels: [], actual_costs: [], standard_costs: [] };
+		
+			data.forEach(row => {
+				const article = row.article_number || '';
+				const supplier = row.supplier || '';
+				labels.push(`${article} (${supplier})`);
+				actual_costs.push(Number(row.real_emission_cost) || 0);
+				standard_costs.push(Number(row.standard_emission_cost) || 0);
+			});
+		
+			return {
+				labels,
+				actual_costs,
+				standard_costs
+			};
+		}
+		
+
+        // Update chart live when selection changes if toggle is ON
+        function bind_datatable_selection_events() {
+            if (!datatable) return;
+            datatable.on('onCheckRow', function() {
+                if ($('#selected-rows-toggle').is(':checked')) {
+                    const selectedData = get_selected_rows_data();
+                    update_chart(get_chart_data(selectedData));
+                }
+            });
+            datatable.on('onUncheckRow', function() {
+                if ($('#selected-rows-toggle').is(':checked')) {
+                    const selectedData = get_selected_rows_data();
+                    update_chart(get_chart_data(selectedData));
+                }
+            });
+        }
+
         /**
          * Render the main page layout.
          * @param {HTMLElement} body
@@ -69,7 +129,21 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
                         <div class="row gx-3" id="compact-stat-row"></div>
                     </div>
                     <div class="frappe-card mb-4" id="chart-section"></div>
-                    
+                    <div class="frappe-card mb-4" id="table-toggle-section">
+                        <div class="p-2 d-flex align-items-center gap-5">
+                            <span class="ms-2 small">Show Cost per tonne</span>&nbsp;
+                            <label class="switch-compact mb-0 me-4 ms-2">
+                                <input type="checkbox" id="table-toggle">
+                                <span class="slider-compact round"></span>
+                            </label>
+                            <span class="vr mx-3"></span>
+                            <span class="ms-2 small">Show Selected rows</span>&nbsp;
+                            <label class="switch-compact mb-0 ms-2">
+                                <input type="checkbox" id="selected-rows-toggle">
+                                <span class="slider-compact round"></span>
+                            </label>
+                        </div>
+                    </div>
                     <div class="frappe-card mb-4" id="table-scroll-container" style="overflow-x: auto;">
                         <div id="table-section"></div>
                     </div>
@@ -562,6 +636,7 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
                                 className: 'frappe-datatable',
                                 checkboxColumn: true, 
                             });
+                            bind_datatable_selection_events();
                         } else {
                             datatable.refresh(all_data);
                         }
@@ -653,21 +728,7 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
                 console.log('Table toggle changed:', isVisible);
                 
                 // Example: Show/hide table
-                if (isVisible) {
-                    $('#table-scroll-container').show();
-                    $('#pagination-controls').show();
-                } else {
-                    $('#table-scroll-container').hide();
-                    $('#pagination-controls').hide();
-                }
-                
-                // Add your custom logic here
-                // For example:
-                // - Trigger different data loading
-                // - Change chart display
-                // - Update filters
-                // - Show/hide other sections
-                // - etc.
+              
             });
         }
     })();

--- a/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.js
+++ b/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.js
@@ -18,7 +18,7 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
 
         // Layout
         render_layout(page.body);
-        inject_custom_styles(page.body);
+        cbam.inject_custom_styles(page.body);
 
         // Filters
         const filters = setup_filters();
@@ -34,11 +34,33 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
 
         // Initial Stats, Chart, and Table
         clear_stats();
-        update_chart(null);
+        cbam.update_chart(null);
         load_report_table(true);
 
         // Setup table toggle functionality
         setup_table_toggle();
+
+        // Helper: Get table data, optionally per tonne
+        function get_table_data(data, per_tonne = false) {
+            return data.map(row => {
+                if (!per_tonne) return { ...row };
+                const mass = Number(row.raw_mass) || 0;
+                let mass_tonnes = mass / 1000;
+                if (mass_tonnes > 0) {
+                    return {
+                        ...row,
+                        real_emission_cost: (Number(row.real_emission_cost) || 0) / mass_tonnes,
+                        standard_emission_cost: (Number(row.standard_emission_cost) || 0) / mass_tonnes
+                    };
+                } else {
+                    return {
+                        ...row,
+                        real_emission_cost: 0,
+                        standard_emission_cost: 0
+                    };
+                }
+            });
+        }
 
         // --- Show Selected Rows Toggle Logic ---
         function get_selected_rows_data() {
@@ -47,55 +69,55 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
             return selectedIndexes.map(idx => all_data[idx]);
         }
 
-        // Listen for toggle event
-        $('#selected-rows-toggle').on('change', function() {
-            const showSelected = $(this).is(':checked');
+        // Listen for 'Show Cost per tonne' toggle event
+        $('#table-toggle').on('change', function() {
+            const per_tonne = $(this).is(':checked');
+            // Update table
+            const table_data = get_table_data(all_data, per_tonne);
+            if (datatable) {
+                datatable.refresh(table_data);
+            }
+            // Update chart (respect 'Show Selected rows' toggle)
+            const showSelected = $('#selected-rows-toggle').is(':checked');
             let chart_data;
             if (showSelected) {
                 const selectedData = get_selected_rows_data();
-                chart_data = get_chart_data(selectedData);
+                chart_data = cbam.get_chart_data(selectedData, per_tonne);
             } else {
-                chart_data = get_chart_data(all_data);
+                chart_data = cbam.get_chart_data(all_data, per_tonne);
             }
-            update_chart(chart_data);
+            cbam.update_chart(chart_data);
         });
 
-		function get_chart_data(data) {
-			// data: array of row objects
-			const labels = [];
-			const actual_costs = [];
-			const standard_costs = [];
-			if (!data) return { labels: [], actual_costs: [], standard_costs: [] };
-		
-			data.forEach(row => {
-				const article = row.article_number || '';
-				const supplier = row.supplier || '';
-				labels.push(`${article} (${supplier})`);
-				actual_costs.push(Number(row.real_emission_cost) || 0);
-				standard_costs.push(Number(row.standard_emission_cost) || 0);
-			});
-		
-			return {
-				labels,
-				actual_costs,
-				standard_costs
-			};
-		}
-		
+        // Listen for 'Show Selected rows' toggle event
+        $('#selected-rows-toggle').on('change', function() {
+            const showSelected = $(this).is(':checked');
+            const per_tonne = $('#table-toggle').is(':checked');
+            let chart_data;
+            if (showSelected) {
+                const selectedData = get_selected_rows_data();
+                chart_data = cbam.get_chart_data(selectedData, per_tonne);
+            } else {
+                chart_data = cbam.get_chart_data(all_data, per_tonne);
+            }
+            cbam.update_chart(chart_data);
+        });
 
-        // Update chart live when selection changes if toggle is ON
+        // Update chart live when selection changes if 'Show Selected rows' is ON
         function bind_datatable_selection_events() {
             if (!datatable) return;
             datatable.on('onCheckRow', function() {
                 if ($('#selected-rows-toggle').is(':checked')) {
                     const selectedData = get_selected_rows_data();
-                    update_chart(get_chart_data(selectedData));
+                    const per_tonne = $('#table-toggle').is(':checked');
+                    cbam.update_chart(cbam.get_chart_data(selectedData, per_tonne));
                 }
             });
             datatable.on('onUncheckRow', function() {
                 if ($('#selected-rows-toggle').is(':checked')) {
                     const selectedData = get_selected_rows_data();
-                    update_chart(get_chart_data(selectedData));
+                    const per_tonne = $('#table-toggle').is(':checked');
+                    cbam.update_chart(cbam.get_chart_data(selectedData, per_tonne));
                 }
             });
         }
@@ -148,110 +170,6 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
                         <div id="table-section"></div>
                     </div>
                 </div>
-            `);
-        }
-
-        /**
-         * Inject custom styles for the page.
-         * @param {HTMLElement} body
-         */
-        function inject_custom_styles(body) {
-            $(body).append(`
-                <style>
-                    .stat-card.frappe-card {
-                        min-width: 230px;
-                        max-width: 260px;
-                    }
-                    .filter-clear-btn {
-                        min-width: 70px;
-                        margin-left: 8px;
-                    }
-                    @media (max-width: 991px) {
-                        .stat-card.frappe-card {
-                            min-width: 180px;
-                            max-width: 100%;
-                        }
-                    }
-                    .dt-cell__content--col-0 {
-                        width: unset !important;
-                    }
-                    /* Checkbox column alignment fix */
-                    .dt-cell--col-0, .dt-header__cell--col-0 {
-                        min-width: 40px !important;
-                        max-width: 40px !important;
-                        width: 40px !important;
-                        text-align: center;
-                    }
-                    /* Table toggle section styles */
-                    #table-toggle-section {
-                        background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
-                        border: 1px solid #dee2e6;
-                    }
-                    /* Compact Toggle Switch Styles */
-                    .switch-compact {
-                        position: relative;
-                        display: inline-block;
-                        width: 40px;
-                        height: 20px;
-                    }
-                    
-                    .switch-compact input {
-                        opacity: 0;
-                        width: 0;
-                        height: 0;
-                    }
-                    
-                    .slider-compact {
-                        position: absolute;
-                        cursor: pointer;
-                        top: 0;
-                        left: 0;
-                        right: 0;
-                        bottom: 0;
-                        background-color: #ccc;
-                        -webkit-transition: .3s;
-                        transition: .3s;
-                    }
-                    
-                    .slider-compact:before {
-                        position: absolute;
-                        content: "";
-                        height: 14px;
-                        width: 14px;
-                        left: 3px;
-                        bottom: 3px;
-                        background-color: white;
-                        -webkit-transition: .3s;
-                        transition: .3s;
-                    }
-                    
-                    input:checked + .slider-compact {
-                        background-color: #2196F3;
-                    }
-                    
-                    input:focus + .slider-compact {
-                        box-shadow: 0 0 1px #2196F3;
-                    }
-                    
-                    input:checked + .slider-compact:before {
-                        -webkit-transform: translateX(20px);
-                        -ms-transform: translateX(20px);
-                        transform: translateX(20px);
-                    }
-                    
-                    .slider-compact.round {
-                        border-radius: 20px;
-                    }
-                    
-                    .slider-compact.round:before {
-                        border-radius: 50%;
-                    }
-                    
-                    #table-toggle-section {
-                        background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
-                        border: 1px solid #dee2e6;
-                    }
-                </style>
             `);
         }
 
@@ -510,84 +428,7 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
             });
         }
 
-        /**
-         * Render or update the chart section.
-         * @param {Object|null} chart_data
-         */
-        function update_chart(chart_data) {
-            $('#chart-section').empty();
 
-            if (!chart_data || !chart_data.labels || chart_data.labels.length === 0) {
-                $('#chart-section').html('<div class="text-center text-muted p-4">No data available for chart</div>');
-                return;
-            }
-
-            // Custom: Concatenate article and supplier for x-axis labels if available
-            let labels = chart_data.labels;
-            let label_map = {};
-            if (chart_data.articles && chart_data.suppliers && Array.isArray(chart_data.articles) && Array.isArray(chart_data.suppliers)) {
-                labels = chart_data.articles.map((article, idx) => {
-                    const supplier = chart_data.suppliers[idx] || '';
-                    const label = `${article} (${supplier})`;
-                    label_map[idx] = label;
-                    return label;
-                });
-            } else {
-                labels = chart_data.labels;
-                labels.forEach((l, idx) => { label_map[idx] = l; });
-            }
-
-            // Highcharts integration: create a scrollable container and chart div
-            const minWidth = Math.max(600, labels.length * 80); // 80px per label as a heuristic
-            $('#chart-section').append('<div id="highchart-scroll-inner" style="overflow-x: auto; width: 100%;"><div id="highchart-bar" style="min-width: ' + minWidth + 'px; max-height: 350px;"></div></div>');
-
-            function renderHighChart() {
-                Highcharts.chart('highchart-bar', {
-                    chart: {
-                        type: 'column',
-                        height: 350
-                    },
-                    credits: {
-                        enabled: false
-                    },
-                    title: { text: __('Standard vs Actual Cost') },
-                    xAxis: {
-                        categories: labels,
-                        labels: {
-                            rotation: 45,
-                            style: { fontSize: '12px' }
-                        }
-                    },
-                    yAxis: {
-                        min: 0,
-                        title: { text: __('Cost') }
-                    },
-                    legend: { align: 'center', verticalAlign: 'bottom', layout: 'horizontal' },
-                    series: [
-                        {
-                            name: __('Actual Cost'),
-                            data: chart_data.actual_costs,
-                            color: '#3b5bdb'
-                        },
-                        {
-                            name: __('Standard Cost'),
-                            data: chart_data.standard_costs,
-                            color: '#fa5252'
-                        }
-                    ]
-                });
-            }
-
-            if (typeof window.Highcharts === 'undefined') {
-                // Dynamically load Highcharts from CDN if not already loaded
-                const script = document.createElement('script');
-                script.src = 'https://code.highcharts.com/highcharts.js';
-                script.onload = () => renderHighChart();
-                document.head.appendChild(script);
-            } else {
-                renderHighChart();
-            }
-        }
 
         /**
          * Load and render the report table and update chart.
@@ -623,11 +464,13 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
                             resizable: true,
                             editable: false
                         }));
+                        const per_tonne = $('#table-toggle').is(':checked');
+                        const table_data = get_table_data(all_data, per_tonne);
                         if (!datatable) {
                             $('#table-section').empty();
                             datatable = new DataTable('#table-section', {
                                 columns: formattedColumns,
-                                data: all_data,
+                                data: table_data,
                                 layout: 'fixed',
                                 stickyHeader: true,
                                 inlineFilters: true,
@@ -638,15 +481,24 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
                             });
                             bind_datatable_selection_events();
                         } else {
-                            datatable.refresh(all_data);
+                            datatable.refresh(table_data);
                         }
-                        update_chart(chart_data);
+                        // Update chart (respect 'Show Selected rows' toggle)
+                        const showSelected = $('#selected-rows-toggle').is(':checked');
+                        let chart_data_final;
+                        if (showSelected) {
+                            const selectedData = get_selected_rows_data();
+                            chart_data_final = cbam.get_chart_data(selectedData, per_tonne);
+                        } else {
+                            chart_data_final = cbam.get_chart_data(all_data, per_tonne);
+                        }
+                        cbam.update_chart(chart_data_final);
                         render_pagination_controls();
                     }
                 },
                 error: function () {
                     $('#table-section').empty().html('<div class="text-center text-muted p-4">Failed to load data</div>');
-                    update_chart(null);
+                    cbam.update_chart(null);
                     render_pagination_controls();
                 }
             });

--- a/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.py
+++ b/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.py
@@ -67,37 +67,9 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
 
     user = frappe.session.user
     declarants = get_declarant_for_user(user)
-    if declarants:
-        declarant_list = ', '.join(f"'{d}'" for d in declarants)
-        where_clauses.append(f"g.declarant IN ({declarant_list})")
 
-    if filters.get("cn_code") and isinstance(filters["cn_code"], list) and len(filters["cn_code"]) > 0:
-        cn_code_list = ', '.join(f"'{c}'" for c in filters["cn_code"])
-        where_clauses.append(f"(g.cn_code IN ({cn_code_list}))")
-        where_clauses_eg.append(f"(eg.cn_code IN ({cn_code_list}))")
-
-    if filters.get("supplier") and isinstance(filters["supplier"], list) and len(filters["supplier"]) > 0:
-        supplier_list = ', '.join(f"'{s}'" for s in filters["supplier"])
-        where_clauses.append(f"(g.supplier_name IN ({supplier_list}))")
-        where_clauses_eg.append(f"(eg.supplier IN ({supplier_list}))")
-
-    if filters.get("article_number") and isinstance(filters["article_number"], list) and len(filters["article_number"]) > 0:
-        article_number_list = ', '.join(f"'{s}'" for s in filters["article_number"])
-        where_clauses.append(f"(g.article_number IN ({article_number_list}))")
-        where_clauses_eg.append(f"(eg.article_no IN ({article_number_list}))")
-    
-    if filters.get("reporting_period") and isinstance(filters["reporting_period"], list) and len(filters["reporting_period"]) > 0:
-        reporting_period_list = ', '.join(f"'{s}'" for s in filters["reporting_period"])
-        where_clauses.append(f"(g.internal_customs_import_number IN ({reporting_period_list}))")
-        where_clauses_eg.append(f"(eg.reporting_period IN ({reporting_period_list}))")
-
-    where_sql = ""
-    if where_clauses:
-        where_sql = "WHERE " + " AND ".join(where_clauses)
-        
-    where_sql_eg = ""
-    if where_clauses_eg:
-        where_sql_eg = "WHERE " + " AND ".join(where_clauses_eg) if where_clauses_eg else ""
+    #set where conditions
+    where_sql, where_sql_eg = set_conditions(declarants, filters, where_clauses, where_clauses_eg)
 
     cbam_factor = float(selected_filters.get('cbam_factor', 0.0) or 0.0)
     bench_mark = float(selected_filters.get('bench_mark', 0.0) or 0.0)
@@ -105,24 +77,7 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
     ets_carbon_price = float(selected_filters.get('ets_price_value', 0.0) or selected_filters.get('ets_price', 0.0) or 0.0)
 
     # Count total rows for pagination
-    count_query = f"""
-        SELECT COUNT(*) FROM (
-            SELECT 
-                eg.cn_code, eg.article_no as article_number, eg.supplier, eg.raw_mass, eg.installation_country,
-                eg.specific_direct_embedded_emissions, eg.carbon_price_due
-            FROM `tabExternal Good` eg
-            {where_sql_eg}
-            
-            UNION
-            SELECT 
-                g.cn_code, g.article_number, g.supplier_name as supplier, g.raw_mass, g.installation_country,
-                g.specific_direct_embedded_emissions, g.carbon_price_due
-            FROM `tabGood` g
-            {where_sql}
-        ) AS count_table
-
-    """
-    total_count = frappe.db.sql(count_query)[0][0]
+    total_count = get_count(where_sql, where_sql_eg)
 
     # Main data query with LIMIT/OFFSET for pagination
     data_query = f"""
@@ -174,6 +129,63 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
     data = frappe.db.sql(data_query, as_dict=1)
     return data, total_count
 
+
+def set_conditions(declarants, filters, where_clauses, where_clauses_eg):
+    if declarants:
+        declarant_list = ', '.join(f"'{d}'" for d in declarants)
+        where_clauses.append(f"g.declarant IN ({declarant_list})")
+
+    if filters.get("cn_code") and isinstance(filters["cn_code"], list) and len(filters["cn_code"]) > 0:
+        cn_code_list = ', '.join(f"'{c}'" for c in filters["cn_code"])
+        where_clauses.append(f"(g.cn_code IN ({cn_code_list}))")
+        where_clauses_eg.append(f"(eg.cn_code IN ({cn_code_list}))")
+
+    if filters.get("supplier") and isinstance(filters["supplier"], list) and len(filters["supplier"]) > 0:
+        supplier_list = ', '.join(f"'{s}'" for s in filters["supplier"])
+        where_clauses.append(f"(g.supplier_name IN ({supplier_list}))")
+        where_clauses_eg.append(f"(eg.supplier IN ({supplier_list}))")
+
+    if filters.get("article_number") and isinstance(filters["article_number"], list) and len(filters["article_number"]) > 0:
+        article_number_list = ', '.join(f"'{s}'" for s in filters["article_number"])
+        where_clauses.append(f"(g.article_number IN ({article_number_list}))")
+        where_clauses_eg.append(f"(eg.article_no IN ({article_number_list}))")
+    
+    if filters.get("reporting_period") and isinstance(filters["reporting_period"], list) and len(filters["reporting_period"]) > 0:
+        reporting_period_list = ', '.join(f"'{s}'" for s in filters["reporting_period"])
+        where_clauses.append(f"(g.internal_customs_import_number IN ({reporting_period_list}))")
+        where_clauses_eg.append(f"(eg.reporting_period IN ({reporting_period_list}))")
+
+    where_sql = ""
+    if where_clauses:
+        where_sql = "WHERE " + " AND ".join(where_clauses)
+        
+    where_sql_eg = ""
+    if where_clauses_eg:
+        where_sql_eg = "WHERE " + " AND ".join(where_clauses_eg) if where_clauses_eg else ""
+
+    return where_sql, where_sql_eg
+
+def get_count(where_sql, where_sql_eg):
+    count_query = f"""
+        SELECT COUNT(*) FROM (
+            SELECT 
+                eg.cn_code, eg.article_no as article_number, eg.supplier, eg.raw_mass, eg.installation_country,
+                eg.specific_direct_embedded_emissions, eg.carbon_price_due
+            FROM `tabExternal Good` eg
+            {where_sql_eg}
+            
+            UNION
+            SELECT 
+                g.cn_code, g.article_number, g.supplier_name as supplier, g.raw_mass, g.installation_country,
+                g.specific_direct_embedded_emissions, g.carbon_price_due
+            FROM `tabGood` g
+            {where_sql}
+        ) AS count_table
+
+    """
+    total_count = frappe.db.sql(count_query)[0][0]
+
+    return total_count
 
 def get_chart_data(data):
     """Process data to create chart data grouped by article and supplier for bar chart"""

--- a/cbam/cbam/page/financial_evaluation_report/style.js
+++ b/cbam/cbam/page/financial_evaluation_report/style.js
@@ -1,0 +1,101 @@
+frappe.provide('cbam')
+
+cbam.inject_custom_styles = function inject_custom_styles(body) {
+    $(body).append(`
+        <style>
+            .stat-card.frappe-card {
+                min-width: 230px;
+                max-width: 260px;
+            }
+            .filter-clear-btn {
+                min-width: 70px;
+                margin-left: 8px;
+            }
+            @media (max-width: 991px) {
+                .stat-card.frappe-card {
+                    min-width: 180px;
+                    max-width: 100%;
+                }
+            }
+            .dt-cell__content--col-0 {
+                width: unset !important;
+            }
+            /* Checkbox column alignment fix */
+            .dt-cell--col-0, .dt-header__cell--col-0 {
+                min-width: 40px !important;
+                max-width: 40px !important;
+                width: 40px !important;
+                text-align: center;
+            }
+            /* Table toggle section styles */
+            #table-toggle-section {
+                background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+                border: 1px solid #dee2e6;
+            }
+            /* Compact Toggle Switch Styles */
+            .switch-compact {
+                position: relative;
+                display: inline-block;
+                width: 40px;
+                height: 20px;
+            }
+            
+            .switch-compact input {
+                opacity: 0;
+                width: 0;
+                height: 0;
+            }
+            
+            .slider-compact {
+                position: absolute;
+                cursor: pointer;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                background-color: #ccc;
+                -webkit-transition: .3s;
+                transition: .3s;
+            }
+            
+            .slider-compact:before {
+                position: absolute;
+                content: "";
+                height: 14px;
+                width: 14px;
+                left: 3px;
+                bottom: 3px;
+                background-color: white;
+                -webkit-transition: .3s;
+                transition: .3s;
+            }
+            
+            input:checked + .slider-compact {
+                background-color: #2196F3;
+            }
+            
+            input:focus + .slider-compact {
+                box-shadow: 0 0 1px #2196F3;
+            }
+            
+            input:checked + .slider-compact:before {
+                -webkit-transform: translateX(20px);
+                -ms-transform: translateX(20px);
+                transform: translateX(20px);
+            }
+            
+            .slider-compact.round {
+                border-radius: 20px;
+            }
+            
+            .slider-compact.round:before {
+                border-radius: 50%;
+            }
+            
+            #table-toggle-section {
+                background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+                border: 1px solid #dee2e6;
+            }
+        </style>
+    `);
+}

--- a/cbam/public/js/es-js/cbam.bundle.js
+++ b/cbam/public/js/es-js/cbam.bundle.js
@@ -1,2 +1,4 @@
 import "cbam/public/js/conf.js";
 import "cbam/public/js/web/website.js";
+import "../../../cbam/page/financial_evaluation_report/chart"
+import "../../../cbam/page/financial_evaluation_report/style"

--- a/cbam/public/js/es-js/cbam.bundle.js
+++ b/cbam/public/js/es-js/cbam.bundle.js
@@ -1,4 +1,5 @@
 import "cbam/public/js/conf.js";
 import "cbam/public/js/web/website.js";
-import "../../../cbam/page/financial_evaluation_report/chart"
-import "../../../cbam/page/financial_evaluation_report/style"
+import "../../../cbam/page/financial_evaluation_report/chart";
+import "../../../cbam/page/financial_evaluation_report/style";
+import "../../../cbam/page/financial_evaluation_report/filter";


### PR DESCRIPTION
**covered Issue:** 

- https://git.phamos.eu/gallehr/cbam/-/work_items/537
- https://git.phamos.eu/gallehr/cbam/-/work_items/536

**Parent Issue:**

- (#537) https://git.phamos.eu/gallehr/cbam/-/issues/535
- (#536) https://git.phamos.eu/gallehr/cbam/-/issues/534

**Summary**

This PR improves the toggle controls in the Financial Evaluation Report page, enhancing both user experience and code maintainability. 

The toggles affected are:

- **Show Cost per tonne:** Allows users to view costs normalized per tonne.
- **Show Selected Rows:** Updates the chart to reflect only the currently selected table rows.

![image](https://github.com/user-attachments/assets/0f2efcb4-2475-47ed-88fe-9148e9cfe9ba)
