### PR TITLE
gallehr/cbam#517: allow chart to show negative values downward

### DIFF
--- a/cbam/cbam/page/financial_evaluation_report/chart.js
+++ b/cbam/cbam/page/financial_evaluation_report/chart.js
@@ -75,7 +75,6 @@ cbam.update_chart = function update_chart(chart_data) {
                 }
             },
             yAxis: {
-                min: 0,
                 title: { text: __('Cost') }
             },
             legend: { align: 'center', verticalAlign: 'bottom', layout: 'horizontal' },


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/517
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/521

**Summary:**

This PR updates the Financial Evaluation Report’s chart configuration to correctly display both positive and negative values for “Actual Cost” and “Standard Cost.” Previously, the chart’s y-axis was fixed at a minimum of zero, which prevented negative values from being visualized. 
Now, the y-axis auto-scales, allowing for clear visualization of fluctuations above and below zero.


![image](https://github.com/user-attachments/assets/d32f4b1f-fd7f-4af1-9459-222f111c0856)
