### PR TITLE
gallehr/cbam#545: updated calculation for Raw Mass [t]

### DIFF
--- a/cbam/cbam/doctype/external_good/external_good.json
+++ b/cbam/cbam/doctype/external_good/external_good.json
@@ -13,6 +13,7 @@
   "supplier",
   "installation_name",
   "raw_mass",
+  "raw_mass_tonne",
   "buying_price_per_mass",
   "calculate",
   "quantity_of_articles",
@@ -180,12 +181,17 @@
    "fieldname": "position_number",
    "fieldtype": "Data",
    "label": "Report Position Number"
+  },
+  {
+   "fieldname": "raw_mass_tonne",
+   "fieldtype": "Float",
+   "label": "Raw Mass [t]"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-02 12:58:41.625026",
+ "modified": "2025-07-08 17:27:02.937388",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "External Good",

--- a/cbam/cbam/doctype/external_good/external_good.py
+++ b/cbam/cbam/doctype/external_good/external_good.py
@@ -6,4 +6,8 @@ from frappe.model.document import Document
 
 
 class ExternalGood(Document):
-	pass
+	def validate(self):
+		if self.raw_mass:
+			self.raw_mass_tonne = float(self.raw_mass) / 1000
+
+

--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -24,6 +24,7 @@
   "values_section",
   "column_break_kaso",
   "raw_mass",
+  "raw_mass_tonne",
   "currency",
   "inward_processing",
   "mass_per_article",
@@ -164,7 +165,7 @@
   {
    "fieldname": "raw_mass",
    "fieldtype": "Float",
-   "label": "Raw mass in Kilograms",
+   "label": "Raw Mass [kg]",
    "non_negative": 1,
    "read_only_depends_on": "eval:doc.manufacture==\"I am NOT the manufacturer of the whole amount of the product\"",
    "reqd": 1
@@ -592,7 +593,7 @@
   {
    "fieldname": "mass_per_article",
    "fieldtype": "Data",
-   "label": "mass per article"
+   "label": "Raw Mass [t]"
   },
   {
    "fieldname": "buying_price",
@@ -618,13 +619,18 @@
    "fieldtype": "Data",
    "label": "Customs Tariff Number",
    "read_only": 1
+  },
+  {
+   "fieldname": "raw_mass_tonne",
+   "fieldtype": "Float",
+   "label": "Raw Mass [t]"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-20 07:25:13.795829",
+ "modified": "2025-07-09 07:03:40.936687",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Good",

--- a/cbam/cbam/doctype/good/good.py
+++ b/cbam/cbam/doctype/good/good.py
@@ -25,6 +25,11 @@ class Good(Document):
 			self.supplier_number, self.supplier_name = frappe.db.get_values("Operating Company", self.operating_company, ['supplier_number', 'supplier_name'])[0]
 
 		self.update_name()
+		self.update_mass_t()
+
+	def update_mass_t(self):
+		if self.raw_mass:
+			self.raw_mass_tonne = float(self.raw_mass) / 1000
 
 	def update_name(self):
 		for row in self.split_details:

--- a/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.js
+++ b/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.js
@@ -44,8 +44,7 @@ frappe.pages['financial-evaluation-report'].on_page_load = function (wrapper) {
         function get_table_data(data, per_tonne = false) {
             return data.map(row => {
                 if (!per_tonne) return { ...row };
-                const mass = Number(row.raw_mass) || 0;
-                let mass_tonnes = mass / 1000;
+                let mass_tonnes = Number(row.raw_mass_tonne) || 0;
                 if (mass_tonnes > 0) {
                     return {
                         ...row,

--- a/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.py
+++ b/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.py
@@ -32,7 +32,7 @@ def get_columns():
         {"fieldname": "cn_code", "fieldtype": "Data", "label": "CN Code", "width": 150},
         {"fieldname": "article_number", "fieldtype": "Data", "label": "Article Number", "width": 200},
         {"fieldname": "supplier", "fieldtype": "Data", "label": "Supplier", "width": 200},
-        {"fieldname": "raw_mass", "fieldtype": "Data", "label": "Mass [kg]", "width": 150},
+        {"fieldname": "raw_mass_tonne", "fieldtype": "Data", "label": "Mass [t]", "width": 150},
         {"fieldname": "carbon_price_due", "fieldtype": "Data", "label": "Carbon Price Due", "width": 150},
         {"fieldname": "installation_country", "fieldtype": "Data", "label": "Installation Country", "width": 180},
         {"fieldname": "real_emission_value", "fieldtype": "Data", "label": "Specific (Direct) Emission Value", "width": 250},
@@ -86,20 +86,20 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                 eg.cn_code,
                 eg.article_no AS article_number,
                 eg.supplier,
-                IFNULL(eg.raw_mass,0.0) AS raw_mass,
+                IFNULL(eg.raw_mass_tonne,0.0) AS raw_mass_tonne,
                 IFNULL(eg.carbon_price_due,0.0) as carbon_price_due,
                 eg.installation_country,
                 IFNULL(eg.specific_direct_embedded_emissions,0.0) AS real_emission_value,             
                 ((
                     IFNULL(eg.specific_direct_embedded_emissions,0.0) - ({cbam_factor} * {bench_mark})
                     - ((IFNULL(eg.specific_direct_embedded_emissions,0.0) * IFNULL(eg.carbon_price_due, 0.0)) / {ets_carbon_price})
-                ) * IFNULL(eg.raw_mass, 0.0) * {ets_carbon_price}) AS real_emission_cost,
+                ) * IFNULL(eg.raw_mass_tonne, 0.0) * {ets_carbon_price}) AS real_emission_cost,
 
                 ((
                     {emission_value}
                     - ({bench_mark} * {cbam_factor})
                     - (({emission_value} * IFNULL(eg.carbon_price_due, 0.0)) / {ets_carbon_price})
-                ) * IFNULL(eg.raw_mass, 0.0) * {ets_carbon_price}) AS standard_emission_cost
+                ) * IFNULL(eg.raw_mass_tonne, 0.0) * {ets_carbon_price}) AS standard_emission_cost
             FROM `tabExternal Good` eg
             {where_sql_eg}
             UNION
@@ -107,20 +107,20 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                 g.cn_code,
                 g.article_number,
                 g.supplier_name AS supplier,
-                IFNULL(g.raw_mass,0.0) AS raw_mass,
+                IFNULL(g.raw_mass_tonne,0.0) AS raw_mass_tonne,
                 IFNULL(g.carbon_price_due,0.0) AS carbon_price_due,
                 g.installation_country,    
                 IFNULL(g.specific_direct_embedded_emissions,0.0) AS real_emission_value,
                 ((
                     IFNULL(g.specific_direct_embedded_emissions,0.0) - ({cbam_factor} * {bench_mark})
                     - ((IFNULL(g.specific_direct_embedded_emissions,0.0) * IFNULL(g.carbon_price_due,0.0)) / {ets_carbon_price})
-                ) * IFNULL(g.raw_mass,0.0) * {ets_carbon_price}) AS real_emission_cost,
+                ) * IFNULL(g.raw_mass_tonne,0.0) * {ets_carbon_price}) AS real_emission_cost,
                 ((
                     {emission_value}
                     - ({bench_mark} * {cbam_factor})
                     - (({emission_value} * IFNULL(g.carbon_price_due, 0.0)) / {ets_carbon_price})
                 )
-                * IFNULL(g.raw_mass, 0.0) * {ets_carbon_price}) AS standard_emission_cost
+                * IFNULL(g.raw_mass_tonne, 0.0) * {ets_carbon_price}) AS standard_emission_cost
             FROM `tabGood` g
             {where_sql}
         ) AS main_table
@@ -169,14 +169,14 @@ def get_count(where_sql, where_sql_eg):
     count_query = f"""
         SELECT COUNT(*) FROM (
             SELECT 
-                eg.cn_code, eg.article_no as article_number, eg.supplier, eg.raw_mass, eg.installation_country,
+                eg.cn_code, eg.article_no as article_number, eg.supplier, eg.raw_mass_tonne, eg.installation_country,
                 eg.specific_direct_embedded_emissions, eg.carbon_price_due
             FROM `tabExternal Good` eg
             {where_sql_eg}
             
             UNION
             SELECT 
-                g.cn_code, g.article_number, g.supplier_name as supplier, g.raw_mass, g.installation_country,
+                g.cn_code, g.article_number, g.supplier_name as supplier, g.raw_mass_tonne, g.installation_country,
                 g.specific_direct_embedded_emissions, g.carbon_price_due
             FROM `tabGood` g
             {where_sql}


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/545
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/521

**Summary:**


- Renamed field in Good:

  - Raw Mass per kg → Raw Mass [kg] for naming consistency with External Good.

- Added field Raw Mass [t] (in tonnes) to both:

  - Good
  - External Good

- Auto-population logic:

  - Raw Mass [t] = Raw Mass [kg] / 1000 (automatically computed on validation).

- Updated child table column to fetch and display:

  - Raw Mass [t] from Good.

![image](https://github.com/user-attachments/assets/0440c2fe-d107-4b50-a8c3-bc240bf2068e)
