### PR TITLE
gallehr/cbam#545: revert change for label

### DIFF
--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -593,7 +593,7 @@
   {
    "fieldname": "mass_per_article",
    "fieldtype": "Data",
-   "label": "Raw Mass [t]"
+   "label": "Mass per article"
   },
   {
    "fieldname": "buying_price",
@@ -630,7 +630,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-09 07:03:40.936687",
+ "modified": "2025-07-09 07:38:29.464808",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Good",


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/545
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/521

Summary:

Revert updation for the label (mass per article)