### PR TITLE
gallehr/cbam#555: Ranaming of CN Benchmark

### DIFF
--- a/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.js
+++ b/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, phamos GmbH and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("CN Code Bench Mark Emission Value", {
+// frappe.ui.form.on("CBAM Benchmark", {
 // 	refresh(frm) {
 
 // 	},

--- a/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.json
+++ b/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.json
@@ -24,7 +24,7 @@
   {
    "fieldname": "bench_mark",
    "fieldtype": "Data",
-   "label": "Bench Mark Emission Value [tCO2/tproduct]"
+   "label": "Emission Benchmark [tCO2/tproduct]"
   },
   {
    "default": "CN-BM-",
@@ -53,10 +53,10 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-02 08:44:13.517268",
+ "modified": "2025-07-09 07:56:12.685414",
  "modified_by": "Administrator",
  "module": "CBAM",
- "name": "CN Code Bench Mark Emission Value",
+ "name": "CBAM Benchmark",
  "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [

--- a/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.py
+++ b/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class CNCodeBenchMarkEmissionValue(Document):
+class CBAMBenchmark(Document):
 	pass

--- a/cbam/cbam/doctype/cbam_benchmark/test_cbam_benchmark.py
+++ b/cbam/cbam/doctype/cbam_benchmark/test_cbam_benchmark.py
@@ -5,5 +5,5 @@
 from frappe.tests.utils import FrappeTestCase
 
 
-class TestCNCodeBenchMarkEmissionValue(FrappeTestCase):
+class TestCBAMBenchmark(FrappeTestCase):
 	pass

--- a/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.py
+++ b/cbam/cbam/page/financial_evaluation_report/financial_evaluation_report.py
@@ -248,7 +248,7 @@ def get_cards_value(filters=None):
             sev.emission_value,
             ecp.price AS ets_price
         FROM `tabCBAM Factor` cf
-        LEFT JOIN `tabCN Code Bench Mark Emission Value` cnb 
+        LEFT JOIN `tabCBAM Benchmark` cnb 
             ON cnb.year = %(year)s
         LEFT JOIN `tabStandard Emission Value` sev 
             ON sev.year = %(year)s

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.py
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.py
@@ -209,7 +209,7 @@ def get_data(filters=None):
         LEFT JOIN `tabStandard Emission Value` e 
             ON eg.cn_code = e.cn_code AND eg.installation_country = e.country
             
-        LEFT JOIN `tabCN Code Bench Mark Emission Value` b 
+        LEFT JOIN `tabCBAM Benchmark` b 
             ON b.cn_code = eg.cn_code
 
         LEFT JOIN `tabReporting Period` rp
@@ -253,7 +253,7 @@ def get_data(filters=None):
 
         LEFT JOIN `tabStandard Emission Value` e 
             ON g.cn_code = e.cn_code AND g.installation_country = e.country
-        LEFT JOIN `tabCN Code Bench Mark Emission Value` b 
+        LEFT JOIN `tabCBAM Benchmark` b 
             ON b.cn_code = g.cn_code
  
         LEFT JOIN `tabReporting Period` rp 


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/555
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/550

Summary:

- Renamed Doctype from "CN Code Bench Mark Emission Value" to "CBAM Benchmark" and field from "Bench Mark Emission Value [tCO2/tproduct]" to "Emission Benchmark [tCO2/tproduct]" for clarity and consistency.

- Performed testing to ensure data integrity, UI reflection, and no impact on linked workflows or permissions.

![image](https://github.com/user-attachments/assets/d09db0ab-653f-4711-b577-6387957dda94)
