### PR TITLE
One time confirmation of Data on submit

### DIFF
--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -42,12 +42,15 @@
   "supplier_section",
   "operating_company",
   "country",
+  "street_and_number",
   "column_break_lqxr",
   "supplier_name",
   "city",
+  "company_email",
   "column_break_fkqq",
   "supplier_number",
   "zip_code",
+  "company_phone_number",
   "section_break_kbvy",
   "declarant",
   "column_break_rtyx",
@@ -624,13 +627,31 @@
    "fieldname": "raw_mass_tonne",
    "fieldtype": "Float",
    "label": "Raw Mass [t]"
+  },
+  {
+   "fieldname": "street_and_number",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Street and Number"
+  },
+  {
+   "fieldname": "company_email",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Company Email"
+  },
+  {
+   "fieldname": "company_phone_number",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Company Phone Number"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-09 07:38:29.464808",
+ "modified": "2025-07-08 13:25:37.215898",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Good",

--- a/cbam/cbam/doctype/good/good.py
+++ b/cbam/cbam/doctype/good/good.py
@@ -320,3 +320,20 @@ def send_data_request(goods):
 			frappe.db.set_value("Good", g.get("name"), "status", "Data Requested")
 
 
+@frappe.whitelist()
+def get_supplier_snapshot():
+    # Same method you use on frontend
+    from cbam.utils.supplier import get_supplier
+    return get_supplier()
+
+def on_submit(doc, method):
+    # Get supplier snapshot
+    supplier = get_supplier_snapshot()
+
+    # Set snapshot fields on Good
+    doc.country = supplier.get("country")
+    doc.city = supplier.get("city")
+    doc.zip_code = supplier.get("zip_code")
+    doc.street_and_number = supplier.get("street_and_number")
+    doc.company_email = supplier.get("company_email")
+    doc.company_phone_number = supplier.get("company_phone_number")

--- a/cbam/cbam/doctype/operating_company/operating_company.py
+++ b/cbam/cbam/doctype/operating_company/operating_company.py
@@ -209,3 +209,28 @@ def send_bulk_signup_request(operating_companys):
 		for company in operating_companys:
 			operating_company = frappe.get_doc("Operating Company", company.get("name"))
 			operating_company.send_signup_request()
+
+
+
+
+def update_goods_on_operating_company_change(doc, method):
+    # Fetch all Goods records linked to this Operating Company and not "Data Submitted"
+    goods_list = frappe.get_all("Good", 
+        filters={
+            "operating_company": doc.name,
+            "status": ["!=", "Data Submitted"]
+        },
+        fields=["name"]
+    )
+
+    for good in goods_list:
+        good_doc = frappe.get_doc("Good", good.name)
+        good_doc.country = doc.country
+        good_doc.city = doc.city
+        good_doc.zip_code = doc.zip_code
+        good_doc.street_and_number = doc.street_and_number
+        good_doc.company_email = doc.company_email
+        good_doc.company_phone_number = doc.company_phone_number
+        good_doc.supplier_name = doc.supplier_name
+        good_doc.save(ignore_permissions=True)
+

--- a/cbam/hooks.py
+++ b/cbam/hooks.py
@@ -165,6 +165,13 @@ after_migrate = [
 # 	}
 # }
 
+doc_events = {
+    "Operating Company": {
+        "on_update": "cbam.cbam.doctype.operating_company.operating_company.update_goods_on_operating_company_change"
+    }
+}
+
+
 # Scheduled Tasks
 # ---------------
 

--- a/cbam/utils/supplier.py
+++ b/cbam/utils/supplier.py
@@ -7,7 +7,12 @@ def get_supplier():
     filters = {"commercial_contact_user": frappe.session.user}
     if "CBAM Representative" in frappe.get_roles() and not "Commercial Contact" in frappe.get_roles():
         filters = {"cbam_representative_user": frappe.session.user}
-    return frappe.db.get_value("Operating Company", filters, "name")
+
+    return frappe.get_value("Operating Company", filters, [
+        "name", "supplier_name", "company_phone_number", "company_email",
+        "street_and_number", "zip_code", "city", "country", "cbam_representive_last_name", "cbam_representive_employee_email", "cbam_representive_employee_position", "cbam_representive_employee_first_name", "cbam_representive_employee_phone_number"
+    ], as_dict=True) or {}
+
 
 @frappe.whitelist()
 def confirm_details(values):

--- a/cbam/www/goods_list/index.js
+++ b/cbam/www/goods_list/index.js
@@ -639,29 +639,87 @@ function executeJS() {
     }
 
 
-    CreateEmissionSubmissionDialog = async function(goods){
-        let supplier_details = await cbam.supplier.get_supplier_details();
-        if (supplier_details.status!="Company Verified"){
-            const cc_add = __("Company Contact and Address")
-            const cbr_details = __("CBAM Representative Details")
-            let d = new frappe.ui.Dialog({ 
-                title: `Please Confirm your Operating Company Details`,
+const CreateEmissionSubmissionDialog = async function(goods) {
+    let current_user_email = frappe.session.user;
+
+    // Get last submitted Good by this user
+    let existing_good = await frappe.call({
+        method: "frappe.client.get_list",
+        args: {
+            doctype: "Good",
+            filters: {
+                cbam_representative_email: current_user_email,
+                status: "Data Submitted"
+            },
+            fields: ["name"],
+            order_by: "modified desc",
+            limit_page_length: 1
+        }
+    });
+
+    // Get supplier details ONCE
+    let supplier_details = await cbam.supplier.get_supplier();
+
+    if (existing_good.message && existing_good.message.length > 0) {
+        let last_good_response = await frappe.call({
+            method: "frappe.client.get",
+            args: {
+                doctype: "Good",
+                name: existing_good.message[0].name,
                 fields: [
+                    "country",
+                    "city",
+                    "zip_code",
+                    "street_and_number",
+                    "company_email",
+                    "company_phone_number"
+                ]
+            }
+        });
+
+        let last_good = last_good_response.message;
+
+        // Normalize helper
+        function normalize(val) {
+            return (val || '').toString().trim().toLowerCase();
+        }
+
+        // Actual comparison
+        let has_changed = (
+            normalize(last_good.country) !== normalize(supplier_details.country) ||
+            normalize(last_good.city) !== normalize(supplier_details.city) ||
+            normalize(last_good.zip_code) !== normalize(supplier_details.zip_code) ||
+            normalize(last_good.street_and_number) !== normalize(supplier_details.street_and_number) ||
+            normalize(last_good.company_email) !== normalize(supplier_details.company_email) ||
+            normalize(last_good.company_phone_number) !== normalize(supplier_details.company_phone_number)
+        );
+
+        if (!has_changed) {
+            SubmissionDialog(goods);
+            return;
+        } else {
+            console.log(" Change detected — showing confirmation popup.");
+        }
+    }
+
+    // Show popup
+    if (supplier_details.status !== "Company Verified") {
+        const cc_add = __("Company Contact and Address");
+        let d = new frappe.ui.Dialog({
+            title: __("Please Confirm your Operating Company Details"),
+            fields: [
                     {
                         label: __("Operating Company Name"),
                         fieldname: "supplier_name",
                         fieldtype: "Data",
                         
                         default: supplier_details.supplier_name,
-                        read_only:1
-                        //options: "\nSub Supplier\nCollegue"
+                        read_only: 1
                     },
                     {
-                        label: `<strong>${cc_add}</strong>`,
+                        label: `<strong>${__("Company Contact and Address")}</strong>`,
                         fieldname: "sb1",
-                        fieldtype: "Section Break",
-                        
-                        
+                        fieldtype: "Section Break"
                     },
                     {
                         label: __("Company Phone Number"),
@@ -701,10 +759,8 @@ function executeJS() {
                     },
                     {
                         label: __(""),
-                        fieldname: "cb1",
-                        fieldtype: "Column Break",
-                        
-                        
+                        fieldname: "cb2",
+                        fieldtype: "Column Break"
                     },
                     {
                         label: __("City"),
@@ -716,21 +772,20 @@ function executeJS() {
                     {
                         label: __("Country"),
                         fieldname: "country",
-                        fieldtype: "Autocomplete",
-                        options: await cbam.utils.get_links("Country"),
+                        fieldtype: "Data",
                         default: supplier_details.country,
                         reqd: 1
                     },
                     {
-                        label: `<strong>${cbr_details}</strong>`,
-                        fieldname: "sb1",
-                        fieldtype: "Section Break",                        
+                        label: `<strong>${__("CBAM Representative Details")}</strong>`,
+                        fieldname: "sb3",
+                        fieldtype: "Section Break"
                     },
                     {
-                        label: __("CBAM Representative Last Name"),
-                        fieldname: "cbam_representive_last_name",
+                        label: __("CBAM Representative First Name"),
+                        fieldname: "cbam_representive_employee_first_name",
                         fieldtype: "Data",
-                        default: supplier_details.cbam_representive_last_name,
+                        default: supplier_details.cbam_representive_employee_first_name,
                         reqd: 1
                     },
                     {
@@ -738,7 +793,7 @@ function executeJS() {
                         fieldname: "cbam_representive_employee_email",
                         fieldtype: "Data",
                         default: supplier_details.cbam_representive_employee_email,
-                        reqd: supplier_details.cbam_representative_user ? 0 : 1 ,
+                        reqd: supplier_details.cbam_representative_user ? 0 : 1,
                         read_only: supplier_details.cbam_representative_user ? 1 : 0
                     },
                     {
@@ -750,16 +805,14 @@ function executeJS() {
                     },
                     {
                         label: __(""),
-                        fieldname: "cb2",
-                        fieldtype: "Column Break",
-                        
-                        
+                        fieldname: "cb4",
+                        fieldtype: "Column Break"
                     },
                     {
-                        label: __("CBAM Representative First Name"),
-                        fieldname: "cbam_representive_employee_first_name",
+                        label: __("CBAM Representative Last Name"),
+                        fieldname: "cbam_representive_last_name",
                         fieldtype: "Data",
-                        default: supplier_details.cbam_representive_employee_first_name,
+                        default: supplier_details.cbam_representive_last_name,
                         reqd: 1
                     },
                     {
@@ -768,34 +821,24 @@ function executeJS() {
                         fieldtype: "Data",
                         default: supplier_details.cbam_representive_employee_phone_number,
                         reqd: 1
-                    },
-                    
+                    }
                 ],
-                size: 'extra-large', // small, large, extra-large 
-                primary_action_label: __('Confirm Details'),
-                //secondary_action_label: '',
-                primary_action(values) {
-                    values.varify = true
-                    cbam.supplier.confirm_details(values)
-                    d.hide();
-                    SubmissionDialog(goods)
-                },
-                secondary_action(values) {
-                    
-                    
-                    
-                    no+=1
-                    
-                }
-            });
-            d.show()
-        }
-        else{
-            SubmissionDialog(goods)    
-        }
-        
-        
+            size: 'extra-large',
+            primary_action_label: __('Confirm Details'),
+            primary_action(values) {
+                cbam.supplier.confirm_details(values);
+                d.hide();
+                SubmissionDialog(goods);
+            }
+        });
+        d.show();
+    } else {
+        SubmissionDialog(goods);
     }
+};
+
+
+
 
     if(document.querySelector(".list-container")) {
         const contentContainer = document.querySelectorAll(".content-container");


### PR DESCRIPTION
**- Description:**

- Added 3 hidden fields in the **good doctype** to get data of the last submitted good and to compare with the new one that is going to be submitted.
- When anything updates in the operating company, it changes in all goods except submitted entries.
- Updated scenarios to get a pop-up on conditions.

**Testing:**
**Scenario 1:**

Initially, it shows the operating company pop-up when no data is submitted in the Goods list.

**Scenario 2:**

When some data has a status of "Data Submitted" and the currently operating company matches the last submitted company, then it only shows the submission popup.

**Scenario 3:**

When some data has the status = "Data Submitted," but the currently operating company data changes, then it shows the operating company confirmation pop-up and also the submission pop-up.


Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/527
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/417

Screenshot
![Peek 2025-07-08 15-58](https://github.com/user-attachments/assets/a4ad34b6-e2a4-4feb-b211-7088117a2e56)
