### PR TITLE
gallehr/cbam#545: validate raw_mass and raw_mass_tonne and calculate …

### DIFF
--- a/cbam/cbam/doctype/external_good/external_good.js
+++ b/cbam/cbam/doctype/external_good/external_good.js
@@ -17,7 +17,21 @@ frappe.ui.form.on("External Good", {
       });
     }
   },
+  raw_mass_tonne(frm) {
+      if (frm.doc.raw_mass_tonne != null) {
+          const value = flt(frm.doc.raw_mass_tonne) * 1000;
+          if (flt(frm.doc.raw_mass) !== value) {
+              frm.set_value("raw_mass", value);
+          }
+      }
+  },
   raw_mass: function (frm) {
+    if (frm.doc.raw_mass != null) {
+      const value = flt(frm.doc.raw_mass) / 1000;
+      if (flt(frm.doc.raw_mass_tonne) !== value) {
+          frm.set_value("raw_mass_tonne", value);
+      }
+    }
     calculate_quantity(frm);
     calculate_mass_per_article(frm);
   },

--- a/cbam/cbam/doctype/external_good/external_good.py
+++ b/cbam/cbam/doctype/external_good/external_good.py
@@ -6,8 +6,6 @@ from frappe.model.document import Document
 
 
 class ExternalGood(Document):
-	def validate(self):
-		if self.raw_mass:
-			self.raw_mass_tonne = float(self.raw_mass) / 1000
+	pass
 
 

--- a/cbam/cbam/doctype/good/good.js
+++ b/cbam/cbam/doctype/good/good.js
@@ -19,6 +19,22 @@ frappe.ui.form.on('Good', {
                 }
             }
         });
+    },
+    raw_mass(frm) {
+        if (frm.doc.raw_mass != null) {
+            const value = flt(frm.doc.raw_mass) / 1000;
+            if (flt(frm.doc.raw_mass_tonne) !== value) {
+                frm.set_value("raw_mass_tonne", value);
+            }
+        }
+    },
+    raw_mass_tonne(frm) {
+        if (frm.doc.raw_mass_tonne != null) {
+            const value = flt(frm.doc.raw_mass_tonne) * 1000;
+            if (flt(frm.doc.raw_mass) !== value) {
+                frm.set_value("raw_mass", value);
+            }
+        }
     }
 })
 

--- a/cbam/cbam/doctype/good/good.py
+++ b/cbam/cbam/doctype/good/good.py
@@ -14,7 +14,6 @@ class Good(Document):
 			prefix = self.parent_good
 			self.name = f'{prefix}-{getseries(prefix, 2)}'
 
-
 	def validate(self):
 		self.set_countries()
 		if self.supplier_number and self.supplier_name:
@@ -24,12 +23,7 @@ class Good(Document):
 		if self.operating_company:
 			self.supplier_number, self.supplier_name = frappe.db.get_values("Operating Company", self.operating_company, ['supplier_number', 'supplier_name'])[0]
 
-		self.update_name()
 		self.update_mass_t()
-
-	def update_mass_t(self):
-		if self.raw_mass:
-			self.raw_mass_tonne = float(self.raw_mass) / 1000
 
 	def update_name(self):
 		for row in self.split_details:


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/545
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/521

**Description:**

Enhancements in Good Doctype Client Script:

- Implemented bi-directional auto-calculation between:

  - Raw Mass [kg] → Raw Mass [t]

  - Raw Mass [t] → Raw Mass [kg]

- Ensured both fields stay synchronized on user input.
- Added value change checks to prevent infinite loops or redundant updates
- Improved float handling using flt() for stability.


