### PR TITLE
Minor amendments in Installation list in website (#439)

### DIFF
--- a/cbam/templates/installation_partial.html
+++ b/cbam/templates/installation_partial.html
@@ -120,14 +120,14 @@
 			<tr>
 				<td width=""><strong>{{_('Sr.')}}</strong></td>
 				
-				<td><strong>{{_('Label')}}</strong></td>
-				<td><strong>{{_('Specific (direct) embedded emissions [tCO2/t]')}}</strong></td>
-				<td width=""><strong>{{_('Source of electricity')}}</strong></td>
+				<td><strong>{{_('Emission Label')}}</strong></td>
+				<td><strong>{{_('Specific (Direct) Embedded Emissions [tCO2/t]')}}</strong></td>
+				<td width=""><strong>{{_('Source of Electricity')}}</strong></td>
 				<td width=""><strong>{{_('Production Method')}}</strong></td>
-				<td><strong>{{_('Electricity consumed [MWh/t]')}}</strong></td>
-				<td><strong>{{_('Indirect Emission Factor [tCO2/MWh]')}}</strong></td>
-				<td><strong>{{_('Source of Indirect Emission Factor')}}</strong></td>
-				<td><strong>{{_('Specific (indirect) embedded emissions [tCO2/t]')}}</strong></td>
+				<td><strong>{{_('Electricity Consumed [MWh/t]')}}</strong></td>
+				<td><strong>{{_('Electricity Emission Factor [tCO2/MWh]')}}</strong></td>
+				<td><strong>{{_('Source of Electricity Emission Factor')}}</strong></td>
+				<td><strong>{{_('Specific (Indirect) Embedded Emissions [tCO2/t]')}}</strong></td>
 				<td><strong>{{_('Edit Emission')}}</strong></td>
 			</tr>
 			
@@ -143,7 +143,7 @@
 				<td>{{i.electricity_consumed}}</td>
 				<td>{{i.indirect_emission_factor}}</td>
 				<td>{{i.source_of_indirect_emission_factor or ""}}</td>
-				<td>{{i.specific_indirect_embedded_emissions}}</td>
+				<td>{{i.specific_indirect_embedded_emissions or ""}}</td>
 				<td style="text-align: center;">
 				<button class="btn btn-secondary btn-sm secondary-action edit-emission" data-emission="{{i.name}}">
 					{{_('Edit')}}


### PR DESCRIPTION
**Description:**
If the Electricity Emission Factor is 0, then the fields that depend on it show null/empty.
The labels in the Emission table are updated.

Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/547
Parent Issue:  https://git.phamos.eu/gallehr/cbam/-/issues/439

Screenshot:
![image](https://github.com/user-attachments/assets/60a5ff2c-8119-4933-9dbc-f4df1311a9da)

