### PR TITLE
Naming consistency of installation data in webview (#472)

### DIFF
--- a/cbam/cbam/doctype/cbam_emission_data/cbam_emission_data.py
+++ b/cbam/cbam/doctype/cbam_emission_data/cbam_emission_data.py
@@ -6,8 +6,13 @@ from frappe.model.document import Document
 
 
 class CBAMEmissionData(Document):
+	def on_update(self):
+		self.update_good_installation_name()
+		
 	def after_insert(self):
 		self.add_to_installation_cht()
+		self.update_good_installation_name()
+
 
 	def on_trash(self):
 		self.delete_child_from_installation_cht()
@@ -34,3 +39,13 @@ class CBAMEmissionData(Document):
 		linked_goods_list = frappe.get_all("Good", filters={"emission_data": self.name}, fields=["name"], pluck="name")
 		for good in linked_goods_list:
 			frappe.db.set_value("Good", good, "emission_data", None)
+
+
+	def update_good_installation_name(self):
+		if self.operating_company and self.installation_name:
+			good_docs = frappe.get_all("Good", 
+                filters={"operating_company": self.operating_company},
+                fields=["name"]
+            )
+			for good in good_docs:
+				frappe.db.set_value("Good", good.name, "installation_name", self.installation_name)

--- a/cbam/patches.txt
+++ b/cbam/patches.txt
@@ -10,3 +10,6 @@ cbam.patches.set_dup_commercial_cont_notification
 cbam.patches.v15_4_3.update_nav_bar_items
 cbam.patches.v15_4_3.copy_customs_tariff_to_cn_code
 cbam.patches.v15_4_3.create_cn_code
+cbam.patches.v15_4_3.disable_report
+cbam.patches.v15_4_3.update_raw_mass_tonne
+cbam.patches.v15_4_3.update_good_installation_name

--- a/cbam/patches/v15_4_3/update_good_installation_name.py
+++ b/cbam/patches/v15_4_3/update_good_installation_name.py
@@ -1,0 +1,16 @@
+import frappe
+
+def execute():
+    good_docs = frappe.get_all("Good", filters={"operating_company": ["!=", ""]}, fields=["name", "operating_company"])
+
+    for good in good_docs:
+        latest_cbam = frappe.db.get_value(
+            "CBAM Emission Data",
+            {"operating_company": good["operating_company"]},
+            "installation_name",
+            order_by="creation desc"
+        )
+
+        if latest_cbam:
+            frappe.db.set_value("Good", good["name"], "installation_name", latest_cbam)
+            frappe.db.commit()

--- a/cbam/www/goods_list/index.html
+++ b/cbam/www/goods_list/index.html
@@ -290,37 +290,37 @@
                   </div>
 
                   <div class="tc-field-cont field-cont">
-                      <span class="field-label">{{_('Production method')}}</span>
-                      <div class="field tc-field">{{_(doc.production_method) or ""}}</div>
+                      <span class="field-label">{{_('Production Method')}}</span>
+                      <div class="field tc-field" style="height: auto !important; white-space: pre-wrap; overflow-wrap: break-word;">{{_(doc.production_method) or ""}}</div>
                   </div>
 
                   <div class="tc-field-cont field-cont">
-                      <span class="field-label">{{_('Source of electricity')}}</span>
-                      <div class="field tc-field">{{_(doc.source_of_electricity) or ""}}</div>
+                      <span class="field-label">{{_('Source of Electricity')}}</span>
+                      <div class="field tc-field" style="height: auto !important; white-space: pre-wrap; overflow-wrap: break-word;">{{_(doc.source_of_electricity) or ""}}</div>
                   </div>
 
                   <div class="tc-field-cont field-cont">
-                      <span class="field-label">{{_('Specific (direct) embedded emissions [tCO2/t]')}}</span>
+                      <span class="field-label">{{_('Specific (Direct) Embedded Emissions [tCO2/t]')}}</span>
                       <div class="field tc-field">{{_(doc.specific_direct_embedded_emissions) or ""}}</div>
                   </div>
 
                   <div class="tc-field-cont field-cont">
-                      <span class="field-label">{{_('Electricity consumed [MWh/t]')}}</span>
+                      <span class="field-label">{{_('Electricity Consumed [MWh/t]')}}</span>
                       <div class="field tc-field">{{_(doc.electricity_consumed) or ""}}</div>
                   </div>
 
                   <div class="tc-field-cont field-cont">
-                      <span class="field-label">{{_('Indirect Emission Factor [tCO2/MWh]')}}</span>
+                      <span class="field-label">{{_('Electricity Emission Factor [tCO2/MWh]')}}</span>
                       <div class="field tc-field">{{_(doc.indirect_emission_factor) or ""}}</div>
                   </div>
 
                   <div class="tc-field-cont field-cont">
-                      <span class="field-label">{{_('Source of Indirect Emission Factor')}}</span>
-                      <div class="field tc-field">{{_(doc.source_of_indirect_emission_factor) or ""}}</div>
+                      <span class="field-label">{{_('Source of Electricity Emission Factor')}}</span>
+                      <div class="field tc-field" style="height: auto !important; white-space: pre-wrap; overflow-wrap: break-word;">{{_(doc.source_of_indirect_emission_factor) or ""}}</div>
                   </div>
 
                   <div class="tc-field-cont field-cont">
-                      <span class="field-label">{{_('Specific (indirect) embedded emissions [tCO2/t]')}}</span>
+                      <span class="field-label">{{_('Specific (Indirect) Embedded Emissions [tCO2/t]')}}</span>
                       <div class="field tc-field">{{_(doc.specific_indirect_embedded_emissions) or ""}}</div>
                   </div>
               </div>

--- a/cbam/www/installation_list/index.js
+++ b/cbam/www/installation_list/index.js
@@ -292,7 +292,7 @@ function executeJS() {
             title: __("Add New Emission"),
             fields: [
                 {
-                    label: __("Label"),
+                    label: __("Emission Label"),
                     fieldname: "label",
                     fieldtype: "Data",
                     reqd: update ? 0 : 1,


### PR DESCRIPTION
**Description:**

- Updated "Label" to "Emission Label" in the Add Emission popup.
- Updated Installation label to "Emission Label".
- Fields expand with content
    - Production Method
    - Source of electricity
    - Source of Indirect Emission Factor

- "Electricity Emission Factor [tCO2/MWh]" label updated.
- "Source of Electricity Emission Factor" label updated.
- Write a function to update the good "installation_name" field whenever "installation_name" is updated in "CBAM Emission Data"
-Added a patch to get all the installations in good doctype.

Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/546
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/472

screenshot:
![image](https://github.com/user-attachments/assets/52a2d86a-f589-482d-ba3d-2131551a7fa9)
![image](https://github.com/user-attachments/assets/6f6e7790-3d99-446b-a3bb-4458bf7ffd38)
