### PR TITLE
Restricted email to send only once

### DIFF
--- a/cbam/cbam/doctype/operating_company/operating_company.py
+++ b/cbam/cbam/doctype/operating_company/operating_company.py
@@ -35,7 +35,11 @@ class OperatingCompany(Document):
 				self.status = "Pending Verification"		
 			else:
 				frappe.msgprint(MISSING_CONTACT_MESSAGE)
-				notify_system_manager_of_conflict(self.main_contact_employee_email, self.name)
+				# Only send email once
+				if not getattr(self.flags, "conflict_notified", False):
+					notify_system_manager_of_conflict(self.main_contact_employee_email, self.name)
+					self.flags.conflict_notified = True
+
 				self.create_commercial_contact_user = 0
 				self.commercial_contact_user = ""
 				self.status = "Missing Commercial Contact"
@@ -58,7 +62,11 @@ class OperatingCompany(Document):
 				self.status = "Pending Verification"
 			else:
 				frappe.msgprint(MISSING_CONTACT_MESSAGE)
-				notify_system_manager_of_conflict(self.cbam_representive_employee_email, self.name)
+				# Only send email once
+				if not getattr(self.flags, "conflict_notified", False):
+					notify_system_manager_of_conflict(self.cbam_representive_employee_email, self.name)
+					self.flags.conflict_notified = True
+
 				self.cbam_representative_user = ""
 				self.status = "CBAM Rep User Conflict"
 


### PR DESCRIPTION
Description:
Restriction added: If an email is sent for cr_user or cc_user, then don't send it again.
Now, one email is sent to the system manager other is sent for signup (previous logic).

Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/542
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/541

Screenshot:
![Peek 2025-07-10 15-56](https://github.com/user-attachments/assets/cd700fa7-55a3-4aea-af41-16341e16b5f9)
