### PR TITLE
Notify System manger about user conflict (#541)

### DIFF
--- a/cbam/cbam/doctype/operating_company/operating_company.py
+++ b/cbam/cbam/doctype/operating_company/operating_company.py
@@ -151,8 +151,10 @@ class OperatingCompany(Document):
 			if self.commercial_contact_user:
 				self.create_permissions(self.commercial_contact_user)
 
-		if self.parent_operating_company:
+		# Only send signup request if no conflict
+		if self.parent_operating_company and not self.user_conflict:
 			self.send_signup_request()
+
 
 	@frappe.whitelist()
 	def send_signup_request(self):


### PR DESCRIPTION
Description:
Both scenarios are now tested and working fine.
 1: When a user is assigned to OC (user signup email).
 2: When a user is assigned to multiple operating companies (only conflict email sent).
 
 Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/542
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/541

GIF:
![Peek 2025-07-11 18-02](https://github.com/user-attachments/assets/9bd749bf-03c5-49c1-b972-84e36d2e98ff)

