### PR TITLE
Syncing of Name details in operating company with User (#279)

### DIFF
--- a/cbam/cbam/doctype/operating_company/operating_company.js
+++ b/cbam/cbam/doctype/operating_company/operating_company.js
@@ -39,7 +39,7 @@ frappe.ui.form.on("Operating Company", {
                                     d.set_value("email", frm.doc.cbam_representive_employee_email)
                                     d.set_value("position", frm.doc.cbam_representive_employee_position)
                                     d.set_value("last_name", frm.doc.cbam_representive_last_name)
-                                    d.set_value("phone_no", frm.doc.cbam_representive_employee_first_name)
+                                    d.set_value("phone_no", frm.doc.cbam_representive_employee_phone_number)
                                 }
                             }
                         },
@@ -83,7 +83,7 @@ frappe.ui.form.on("Operating Company", {
                     size: 'large',
                     primary_action_label: "Update Contact",
                     primary_action(values){
-                        
+                        values.name = frm.doc.name;
                         frappe.call({
                             method: "update_contact",
                             doc: frm.doc,

--- a/cbam/cbam/doctype/operating_company/operating_company.json
+++ b/cbam/cbam/doctype/operating_company/operating_company.json
@@ -131,12 +131,14 @@
   {
    "fieldname": "main_contact_employee_last_name",
    "fieldtype": "Data",
-   "label": "Commercial Contact Last Name"
+   "label": "Commercial Contact Last Name",
+   "read_only": 1
   },
   {
    "fieldname": "main_contact_employee_first_name",
    "fieldtype": "Data",
-   "label": "Commercial Contact First Name"
+   "label": "Commercial Contact First Name",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_qmcl",
@@ -146,17 +148,20 @@
    "fieldname": "main_contact_employee_email",
    "fieldtype": "Data",
    "label": "Commercial Contact Email",
-   "options": "Email"
+   "options": "Email",
+   "read_only": 1
   },
   {
    "fieldname": "main_contact_employee_phone_number",
    "fieldtype": "Data",
-   "label": "Commercial Contact Phone Number"
+   "label": "Commercial Contact Phone Number",
+   "read_only": 1
   },
   {
    "fieldname": "main_contact_employee_position",
    "fieldtype": "Data",
-   "label": "Commercial Contact Position"
+   "label": "Commercial Contact Position",
+   "read_only": 1
   },
   {
    "fieldname": "cbam_representive_details_section",
@@ -166,12 +171,14 @@
   {
    "fieldname": "cbam_representive_last_name",
    "fieldtype": "Data",
-   "label": "CBAM Representative Last Name"
+   "label": "CBAM Representative Last Name",
+   "read_only": 1
   },
   {
    "fieldname": "cbam_representive_employee_first_name",
    "fieldtype": "Data",
-   "label": "CBAM Representative First Name"
+   "label": "CBAM Representative First Name",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_xrkz",
@@ -181,17 +188,20 @@
    "fieldname": "cbam_representive_employee_email",
    "fieldtype": "Data",
    "label": "CBAM Representative  Email",
-   "options": "Email"
+   "options": "Email",
+   "read_only": 1
   },
   {
    "fieldname": "cbam_representive_employee_phone_number",
    "fieldtype": "Data",
-   "label": "CBAM Representative  Phone Number"
+   "label": "CBAM Representative  Phone Number",
+   "read_only": 1
   },
   {
    "fieldname": "cbam_representive_employee_position",
    "fieldtype": "Data",
-   "label": "CBAM Representative  Position"
+   "label": "CBAM Representative  Position",
+   "read_only": 1
   },
   {
    "fieldname": "goods_list_section",
@@ -281,7 +291,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-20 16:27:56.485260",
+ "modified": "2025-07-16 15:46:25.772764",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Operating Company",

--- a/cbam/cbam/doctype/operating_company/operating_company.py
+++ b/cbam/cbam/doctype/operating_company/operating_company.py
@@ -202,7 +202,6 @@ class OperatingCompany(Document):
 			
 			if not self.check_user_exists(values.email):
 				frappe.throw("This user is already associated with another Operating Company.")
-				return
 			self.cbam_representive_last_name = values.last_name
 			self.cbam_representive_employee_first_name = values.first_name
 			self.cbam_representive_employee_phone_number = values.phone_no
@@ -210,8 +209,57 @@ class OperatingCompany(Document):
 			self.cbam_representive_employee_email = values.email
 			old_user = self.cbam_representative_user
 		self.save()
+
+		user = frappe.get_all("User", filters={"email": values.email}, fields=["name"])
+		if user:
+			user_doc = frappe.get_doc("User", user[0].name)
+			user_doc.first_name = values.first_name
+			user_doc.last_name = values.last_name
+			user_doc.phone = values.phone_no
+			user_doc.save()
+
+		# Disable old user if different
 		if old_user not in [self.cbam_representative_user, self.commercial_contact_user]:
 			frappe.db.set_value("User", old_user, "enabled", 0)
+
+	def on_update(self):
+		# Commercial Contact user update
+		if self.main_contact_employee_email:
+			self.update_user(
+				self.main_contact_employee_email,
+				self.main_contact_employee_first_name,
+				self.main_contact_employee_last_name,
+				self.main_contact_employee_phone_number
+			)
+
+		# CBAM Representative user update
+		if self.cbam_representive_employee_email:
+			self.update_user(
+				self.cbam_representive_employee_email,
+				self.cbam_representive_employee_first_name,
+				self.cbam_representive_last_name,
+				self.cbam_representive_employee_phone_number
+			)
+
+	def update_user(self, email, first_name, last_name, phone_no):
+		user = frappe.get_all("User", filters={"email": email}, fields=["name"])
+		if user:
+			user_doc = frappe.get_doc("User", user[0].name)
+			has_changes = False
+
+			if user_doc.first_name != first_name:
+				user_doc.first_name = first_name
+				has_changes = True
+			if user_doc.last_name != last_name:
+				user_doc.last_name = last_name
+				has_changes = True
+			if user_doc.phone != phone_no:
+				user_doc.phone = phone_no
+				has_changes = True
+
+			if has_changes:
+				user_doc.save()
+
 
 @frappe.whitelist()
 def send_bulk_signup_request(operating_companys):

--- a/cbam/hooks.py
+++ b/cbam/hooks.py
@@ -168,6 +168,9 @@ after_migrate = [
 doc_events = {
     "Operating Company": {
         "on_update": "cbam.cbam.doctype.operating_company.operating_company.update_goods_on_operating_company_change"
+    },
+    "User": {
+        "before_save": "cbam.override.user.update_operating_company_contact"
     }
 }
 

--- a/cbam/override/user.py
+++ b/cbam/override/user.py
@@ -60,3 +60,35 @@ def update_password(
     # Return success message instead of redirect
 	frappe.msgprint(_("Your password has been updated. Please log in manually."))
 	return "/login"
+
+def update_operating_company_contact(doc, method):
+    if frappe.flags.in_user_hook:
+        return
+
+    frappe.flags.in_user_hook = True
+
+    frappe.log_error("User Hook Triggered", f"User: {doc.name}")
+    operating_companies = frappe.get_all("Operating Company", 
+        filters={"commercial_contact_user": doc.name}, fields=["name"])
+
+    for op in operating_companies:
+        op_doc = frappe.get_doc("Operating Company", op.name)
+        op_doc.main_contact_employee_first_name = doc.first_name
+        op_doc.main_contact_employee_last_name = doc.last_name
+        op_doc.main_contact_employee_email = doc.email
+        op_doc.commercial_contact_user = doc.email
+        op_doc.main_contact_employee_phone_number = doc.phone
+        op_doc.save()
+
+    cbam_companies = frappe.get_all("Operating Company", 
+        filters={"cbam_representative_user": doc.name}, fields=["name"])
+
+    for op in cbam_companies:
+        op_doc = frappe.get_doc("Operating Company", op.name)
+        op_doc.cbam_representive_employee_first_name = doc.first_name
+        op_doc.cbam_representive_last_name = doc.last_name
+        op_doc.cbam_representive_employee_email = doc.email
+        op_doc.cbam_representative_user = doc.email
+        op_doc.cbam_representive_employee_phone_number = doc.phone
+        op_doc.save()
+


### PR DESCRIPTION
**Description:**

All Contact fields for CR User and CC User are now read-only.
**- Case 1:** 

- When we update contact details from the popup, it updates the user details as well in the user's doctype.

**Case 2:** 

- When we update user data, then it gets reflected in the Operating company for the specific user(it may be cc user or cr user).

Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/580
parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/579

Screenshot & GIF:
<img width="3222" height="1746" alt="image" src="https://github.com/user-attachments/assets/d4d48d18-ceed-4c5d-9ee8-74f4e5070fb8" />
