### PR TITLE
Non logged should not be able to access website beyond login page

### DIFF
--- a/cbam/hooks.py
+++ b/cbam/hooks.py
@@ -231,8 +231,6 @@ override_whitelisted_methods = {
 
 # Request Events
 # ----------------
-before_request = ["cbam.override.restrict_guest.block_guest"]
-
 # before_request = ["cbam.utils.before_request"]
 # after_request = ["cbam.utils.after_request"]
 

--- a/cbam/override/restrict_guest.py
+++ b/cbam/override/restrict_guest.py
@@ -1,9 +1,0 @@
-import frappe
-
-def block_guest():
-    path = frappe.request.path
-    public_pages = ["/login", "/signup", "/about", "/contact", "/"]
-
-    if frappe.session.user == "Guest" and path not in public_pages:
-        frappe.local.response["type"] = "redirect"
-        frappe.local.response["location"] = "/login"

--- a/cbam/www/emission_data_list/index.html
+++ b/cbam/www/emission_data_list/index.html
@@ -1,4 +1,4 @@
-{% extends "templates/web.html" %}
+{% extends "templates/cbamweb.html" %}
 
 {% block page_content %}
 {% include "templates/includes/web_sidebar.html" %}

--- a/cbam/www/home/index.html
+++ b/cbam/www/home/index.html
@@ -1,4 +1,4 @@
-{% extends "templates/cbamweb.html" %}
+{% extends "templates/web.html" %}
 
 {% set preferred_lang = frappe.request.cookies.get("preferred_language") %}
 {% set user_lang = frappe.db.get_value("User", frappe.session.user, "language") %}

--- a/cbam/www/installation_list/index.html
+++ b/cbam/www/installation_list/index.html
@@ -1,4 +1,4 @@
-{% extends "templates/web.html" %}
+{% extends "templates/cbamweb.html" %}
 
 
 

--- a/cbam/www/operating_company/index.html
+++ b/cbam/www/operating_company/index.html
@@ -1,4 +1,4 @@
-{% extends "templates/web.html" %}
+{% extends "templates/cbamweb.html" %}
 
 {% block page_content %}
 {% include "templates/includes/web_sidebar.html" %}

--- a/cbam/www/supplier_list/index.html
+++ b/cbam/www/supplier_list/index.html
@@ -1,4 +1,4 @@
-{% extends "templates/web.html" %}
+{% extends "templates/cbamweb.html" %}
 
 {% block page_content %}
 {% include "templates/includes/web_sidebar.html" %}


### PR DESCRIPTION
Description:
Remove the previous validation added for the guest user.
Added new condition so that the home page is visible to all, but others are only visible to logged-in users. Guest users are redirected to the Login page, but the home is visible to all users.

Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/588
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/587

Screenshot:
![Peek 2025-07-23 15-18](https://github.com/user-attachments/assets/e368904c-100a-4420-a0eb-ac21c5cccacb)
