### PR TITLE
gallehr/cbam#592: refine code to extract pdf report

### DIFF
--- a/cbam/utils/pdf_export.py
+++ b/cbam/utils/pdf_export.py
@@ -3,6 +3,30 @@ import os
 import re
 import frappe
 
+def extract_numeric_value(text):
+    match = re.search(r'[-+]?\d*\.\d+|\d+', text)
+    if match:
+        return match.group(0)
+    return None
+
+def extract_field(label, lines):
+    for i, l in enumerate(lines):
+        if label.lower() in l.lower():
+            # Look for the next non-empty line after the label
+            for j in range(i + 1, len(lines)):
+                value = lines[j].strip()
+                if value:
+                    return value
+            return None
+    return None
+
+def get_section_value_from_title(section, label, prev_lines):
+    # If the section title is a value and the previous section ended with the label
+    if section and re.match(r'^\d+(\.\d+)?\s*\w+', section):
+        if prev_lines and prev_lines[-1].strip().lower() == label.lower():
+            return section
+    return None
+
 def extract_cbam_goods(pdf_path):
     doc = fitz.open(pdf_path)
     lines = []
@@ -63,18 +87,6 @@ def extract_cbam_goods(pdf_path):
     if current["Section"]:
         good_blocks.append(current)
 
-    def extract_field(label, lines, numeric=False):
-        for i, l in enumerate(lines):
-            if label in l:
-                if ":" in l:
-                    return l.split(":", 1)[1].strip()
-                elif i + 1 < len(lines):
-                    value = lines[i + 1].strip()
-                    if numeric and not re.match(r"^[\d.]+$", value):
-                        continue
-                    return value
-        return None
-
     # Cache CN Code + Procedure Code from main sections like "1", "2", "3"
     parent_values = {}
     for block in good_blocks:
@@ -82,44 +94,68 @@ def extract_cbam_goods(pdf_path):
         if "." not in section:
             parent_values[section] = {
                 "CN Code": block["CN Code"],
-                "Requested Procedure Code": extract_field("Requested procedure code", block["Lines"], numeric=True)
+                "Requested Procedure Code": extract_field("Requested procedure code", block["Lines"])
             }
 
     # Final extraction
     extracted = []
-    for block in good_blocks:
+    last_lines = None
+    frappe.log_error("Good Blocks", good_blocks)
+    for idx, block in enumerate(good_blocks):
         section = block["Section"]
         lines = block["Lines"]
         parent_key = section.split(".")[0]
 
-        # Determine if declarant acts as importer
         declarant = header_info["reporting_declarant"]
         importer = header_info["importer"]
         declarant_acts_as_importer = (declarant == importer) if declarant and importer else False
-        
-        # Set importer value based on logic
         final_importer_value = declarant if declarant_acts_as_importer else importer
-        
+
+        # Get raw and numeric values for emissions fields, handling both structures
+        sdee_raw = extract_field("Specific direct embedded emissions", lines)
+        sdee_attached = False
+        if not sdee_raw:
+            sdee_raw = get_section_value_from_title(section, "Specific direct embedded emissions", last_lines)
+            # If found, attach to previous row
+            if sdee_raw and extracted:
+                extracted[-1]["specific_direct_embedded_emissions"] = sdee_raw
+                extracted[-1]["specific_direct_embedded_emissions_numeric"] = extract_numeric_value(sdee_raw)
+                sdee_attached = True
+        sdee_num = extract_numeric_value(sdee_raw) if sdee_raw and not sdee_attached else None
+
+        sidee_raw = extract_field("Specific indirect embedded emissions", lines)
+        sidee_attached = False
+        if not sidee_raw:
+            sidee_raw = get_section_value_from_title(section, "Specific indirect embedded emissions", last_lines)
+            if sidee_raw and extracted:
+                extracted[-1]["specific_indirect_embedded_emissions"] = sidee_raw
+                extracted[-1]["specific_indirect_embedded_emissions_numeric"] = extract_numeric_value(sidee_raw)
+                sidee_attached = True
+        sidee_num = extract_numeric_value(sidee_raw) if sidee_raw and not sidee_attached else None
+
         data = {
             "section": section,
             "operator_name": extract_field("Operator Name", lines),
             "installation_name": extract_field("Installation name", lines),
             "country_of_production": extract_field("Country code", lines),
             "type_of_measurement_unit": extract_field("Type of measurement unit", lines),
-            "quantity": extract_field("Quantity", lines, numeric=True),
-            "specific_direct_embedded_emissions": extract_field("Specific direct embedded emissions", lines, numeric=True),
-            "specific_indirect_embedded_emissions": extract_field("Specific indirect embedded emissions", lines, numeric=True),
+            "quantity": extract_field("Quantity", lines),
+            "specific_direct_embedded_emissions": sdee_raw if not sdee_attached else None,
+            "specific_direct_embedded_emissions_numeric": sdee_num,
+            "specific_indirect_embedded_emissions": sidee_raw if not sidee_attached else None,
+            "specific_indirect_embedded_emissions_numeric": sidee_num,
             "type_of_determination": extract_field("Type of determination", lines),
-            "requested_procedure_code": extract_field("Requested procedure code", lines, numeric=True) or parent_values.get(parent_key, {}).get("Requested Procedure Code"),
+            "requested_procedure_code": extract_field("Requested procedure code", lines) or parent_values.get(parent_key, {}).get("Requested Procedure Code"),
             "cn_code": block.get("CN Code") or parent_values.get(parent_key, {}).get("CN Code"),
             "reporting_declarant": declarant,
             "importer": final_importer_value,
             "declarant_acts_as_importer": declarant_acts_as_importer
         }
 
-        if data["operator_name"] or data["installation_name"]:
+        # Only add rows with meaningful business data
+        if (data["operator_name"] or data["installation_name"]):
             extracted.append(data)
-            
+        last_lines = lines
     frappe.log_error("Extracted CBAM Goods Data", extracted)
     return extracted
 

--- a/cbam/utils/pdf_export.py
+++ b/cbam/utils/pdf_export.py
@@ -48,8 +48,6 @@ def extract_cbam_goods(pdf_path):
                     if i + 1 < len(page_lines):
                         importer_value = page_lines[i + 1].strip()
                         header_info["importer"] = importer_value
-                        # Log for debugging
-                        frappe.log_error(f"Found importer line: '{line}' -> value: '{importer_value}'", "CBAM Importer Debug")
                         break  # Stop after finding the first importer
 
     # Match section headers like "1. 73181535 | CN"
@@ -100,7 +98,6 @@ def extract_cbam_goods(pdf_path):
     # Final extraction
     extracted = []
     last_lines = None
-    frappe.log_error("Good Blocks", good_blocks)
     for idx, block in enumerate(good_blocks):
         section = block["Section"]
         lines = block["Lines"]
@@ -156,7 +153,6 @@ def extract_cbam_goods(pdf_path):
         if (data["operator_name"] or data["installation_name"]):
             extracted.append(data)
         last_lines = lines
-    frappe.log_error("Extracted CBAM Goods Data", extracted)
     return extracted
 
 


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/592
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/573

Summary:

This PR improves the CBAM PDF data extraction logic to handle both standard and non-standard PDF layouts, ensuring all emission values are captured and only meaningful rows are included in the report.


**Solution**

- Enhanced the extraction logic to:
  - Extract values both after the label and from section titles when the previous section ends with the label.
  - Attach such “section title as value” entries to the correct previous row, instead of creating a new row.
  - Only add rows to the report if they contain meaningful business data (operator or installation info).

- Ensured the report is clean, accurate, and robust to all observed CBAM PDF structures.


| **Structure of Original PDF Report** | **Structure of Dummy PDF Report** |
| ------ | ------ |
|   <img width="1850" height="1450" alt="image" src="https://github.com/user-attachments/assets/7cb99e7a-80cb-4223-a24c-0cd107580a21" />    |    <img width="1876" height="1394" alt="image" src="https://github.com/user-attachments/assets/272bc72d-8d48-485d-9926-b6e5d1423863" />    |
|        |        |


