### PR TITLE
Add toggle switch for tooltip views in Financial Exposure Forecast chart

### DIFF
--- a/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.js
+++ b/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.js
@@ -46,7 +46,7 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                 <a class="nav-link" href="/app/ets-price-dashboard">ETS Price Dashboard</a>
             </li> -->
 			<li class="nav-item">
-                <a class="nav-link active" href="/app/financial-exposure-forecast">Financial Exposure Forecase</a>
+                <a class="nav-link active" href="/app/financial-exposure-forecast">Financial Exposure Forecast</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="/app/various-cost-comparisons">Various Cost Comparisons</a>
@@ -568,7 +568,6 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                     },
                     color: '#003366',
                     showInLegend: true,
-                    tooltip: { pointFormat: '<b>ETS Certificates Required</b><br/>Based on actual data: <b>€{point.y:,.0f}</b>' },
                     zIndex: 3
                 },
                 {
@@ -584,7 +583,6 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                     },
                     color: '#87ceeb',
                     showInLegend: true,
-                    tooltip: { pointFormat: '<b>Minimum Required Account Balance</b><br/>Based on forecast: <b>€{point.y:,.0f}</b>' },
                     zIndex: 3
                 },
                 ...extraLineSeries,
@@ -601,9 +599,58 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                 }
             },
             tooltip: {
+                shared: false,
+                useHTML: true,
                 formatter: function() {
-                    return `<b>${this.x}</b><br/>
-                            <span style="color:${this.color}">●</span> ${this.series.name}: <b>€${this.y.toLocaleString()}</b>`;
+                    // Show both Amount Due and Required Certificates for ALL series
+                    let cost = this.y;  // Use this.y directly
+                    let certText = '';
+                    
+                    // Calculate certificates for ALL series if ETS price is available
+                    if (cost !== null && !isNaN(cost) && typeof this.point.index === 'number' && Array.isArray(chart_data.ets_prices)) {
+                        let ets_price = chart_data.ets_prices[this.point.index];
+                        
+                        // Frontend fallback: if index is beyond array length, use last available price
+                        if (ets_price === undefined && chart_data.ets_prices.length > 0) {
+                            ets_price = chart_data.ets_prices[chart_data.ets_prices.length - 1];
+                        }
+                        
+                        // Validate ETS price before calculation
+                        if (ets_price && !isNaN(ets_price) && isFinite(ets_price) && ets_price > 0) {
+                            let certificates = cost / ets_price;
+                            
+                            // Validate certificate calculation result
+                            if (!isNaN(certificates) && isFinite(certificates) && certificates >= 0) {
+                                // Only show certificates for diamond/overlay series
+                                if (this.series.name.includes('ETS Certificates') || this.series.name.includes('Minimum Required Account Balance')) {
+                                    certText = `<br/><span style=\"color:#888\">Required Certificates:</span> <b>${certificates.toLocaleString(undefined, {maximumFractionDigits: 2})}</b>`;
+                                }
+                            }
+                        }
+                    }
+                    
+                    // Always show Amount Due in € - ensure cost is displayed
+                    let costDisplay = '';
+                    if (cost !== null && !isNaN(cost)) {
+                        costDisplay = `€${cost.toLocaleString()}`;
+                    } else {
+                        costDisplay = '€0';  // Fallback if no cost
+                    }
+                    
+                    // Show different labels based on series type
+                    let seriesLabel = '';
+                    if (this.series.name.includes('ETS Certificates') || this.series.name.includes('Minimum Required Account Balance')) {
+                        // For diamond/overlay series, show "Amount Due"
+                        seriesLabel = 'Amount Due';
+                    } else {
+                        // For main bars, show the original series name
+                        seriesLabel = this.series.name;
+                    }
+                    
+                    let finalTooltip = `<b>${this.x}</b><br/>
+                            <span style=\"color:${this.color}\">●</span> ${seriesLabel}: <b>${costDisplay}</b>${certText}`;
+                    
+                    return finalTooltip;
                 }
             },
             legend: {

--- a/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.js
+++ b/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.js
@@ -291,7 +291,120 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
         return `${day} ${month} ${year}`;
     }
 
+    function ensureObjectPoints(arr) {
+        return arr.map(pt => {
+            if (pt && typeof pt === 'object' && 'y' in pt) return pt;
+            return {y: pt === null || pt === undefined ? null : pt, required_certificates: null};
+        });
+    }
+
     function render_chart(chart_data) {
+        // Remove any existing toggle switch to prevent duplicates
+        $('.tooltip-toggle-container').remove();
+        
+        // Add toggle switch above the chart
+        const toggleHtml = `
+            <div class="tooltip-toggle-container mb-3" style="text-align: center;">
+                <div class="btn-group" role="group" aria-label="Tooltip Display Toggle">
+                    <input type="radio" class="btn-check" name="tooltip-view" id="view-cost" checked>
+                    <label class="btn btn-outline-primary" for="view-cost">
+                        <i class="fas fa-euro-sign"></i> Amount Due in €
+                    </label>
+                    
+                    <input type="radio" class="btn-check" name="tooltip-view" id="view-certificates">
+                    <label class="btn btn-outline-primary" for="view-certificates">
+                        Required Certificates
+                    </label>
+                    
+                    <input type="radio" class="btn-check" name="tooltip-view" id="view-both">
+                    <label class="btn btn-outline-primary" for="view-both">
+                        Both Views
+                    </label>
+                </div>
+            </div>
+            <style>
+                .tooltip-toggle-container {
+                    background: #f8f9fa;
+                    border: 1px solid #e3e6eb;
+                    border-radius: 0.5rem;
+                    padding: 1rem;
+                    margin-bottom: 1rem;
+                    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+                }
+                .tooltip-toggle-container .btn-group {
+                    display: inline-flex;
+                    flex-wrap: wrap;
+                    gap: 0.25rem;
+                }
+                .tooltip-toggle-container .btn {
+                    border-radius: 0.375rem;
+                    font-size: 0.875rem;
+                    font-weight: 500;
+                    padding: 0.5rem 1rem;
+                    transition: all 0.2s ease;
+                    background-color: #ffffff;
+                    border-color: #000000;
+                    color: #000000;
+                }
+                .tooltip-toggle-container .btn-check {
+                    display: none;
+                }
+                .tooltip-toggle-container .btn-check:checked + .btn {
+                    background-color: #000000 !important;
+                    border-color: #000000 !important;
+                    color: white !important;
+                    box-shadow: 0 0 0 0.2rem rgba(0, 0, 0, 0.25);
+                }
+                .tooltip-toggle-container .btn:hover:not(.btn-check:checked + .btn) {
+                    background-color: #e9ecef;
+                    border-color: #adb5bd;
+                    color: #495057;
+                }
+                .tooltip-toggle-container .btn-check:checked + .btn:hover {
+                    background-color: #333333 !important;
+                    border-color: #000000 !important;
+                }
+                .tooltip-toggle-container .btn:focus {
+                    box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.25);
+                    outline: none;
+                }
+                @media (max-width: 768px) {
+                    .tooltip-toggle-container .btn-group {
+                        flex-direction: column;
+                        width: 100%;
+                    }
+                    .tooltip-toggle-container .btn {
+                        width: 100%;
+                        margin-bottom: 0.25rem;
+                    }
+                }
+            </style>
+        `;
+        
+        // Insert toggle above the chart
+        $('#chart-section').before(toggleHtml);
+        
+        // Store the current view preference
+        let currentTooltipView = 'cost'; // 'cost', 'certificates', or 'both'
+        
+        // Handle toggle changes
+        $('input[name="tooltip-view"]').on('change', function() {
+            currentTooltipView = this.id.replace('view-', '');
+            console.log('Tooltip view changed to:', currentTooltipView);
+            
+            // Ensure only one option is selected
+            $('input[name="tooltip-view"]').prop('checked', false);
+            $(this).prop('checked', true);
+            
+            // Add visual feedback
+            $('.tooltip-toggle-container .btn').removeClass('active');
+            $(this).next('label').addClass('active');
+        });
+        
+        // Initialize the first option as selected
+        $('#view-cost').prop('checked', true);
+        $('#view-cost').next('label').addClass('active');
+        
         // Extract and prepare categories
         let categories = chart_data.categories || [];
         let yearDueDatesMap = chart_data.year_due_dates || {};
@@ -377,6 +490,7 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
         if (categories.length > 0 && lastYear) {
             yearDueDates.push({ idx: categories.length - 1, year: lastYear });
         }
+        
         // Debug: log due date, label, index, and categories for each plotLine
         Object.entries(yearDueDatesMap).forEach(([reportingYear, dueDateRaw]) => {
             const d = new Date(dueDateRaw);
@@ -391,6 +505,7 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                 );
             });
         });
+        
         // Plot a vertical line for every reporting year at its due date (even if due date is in the following year)
         const plotLines = Object.entries(yearDueDatesMap).map(([reportingYear, dueDateRaw]) => {
             const d = new Date(dueDateRaw);
@@ -503,7 +618,11 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
             }
         });
 
-        // Render the chart
+        // Only sanitize main cost/forecast series before rendering chart
+        if (Array.isArray(chart_data.series)) {
+            chart_data.series.forEach(s => { s.data = ensureObjectPoints(s.data); });
+        }
+        // Do NOT touch overlays/diamonds logic at all
         Highcharts.chart('chart-section', {
             chart: {
                 type: 'column',
@@ -602,9 +721,10 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                 shared: false,
                 useHTML: true,
                 formatter: function() {
-                    // Show both Amount Due and Required Certificates for ALL series
+                    // Show content based on toggle selection
                     let cost = this.y;  // Use this.y directly
                     let certText = '';
+                    let costDisplay = '';
                     
                     // Calculate certificates for ALL series if ETS price is available
                     if (cost !== null && !isNaN(cost) && typeof this.point.index === 'number' && Array.isArray(chart_data.ets_prices)) {
@@ -629,8 +749,7 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                         }
                     }
                     
-                    // Always show Amount Due in € - ensure cost is displayed
-                    let costDisplay = '';
+                    // Always prepare cost display
                     if (cost !== null && !isNaN(cost)) {
                         costDisplay = `€${cost.toLocaleString()}`;
                     } else {
@@ -647,10 +766,40 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                         seriesLabel = this.series.name;
                     }
                     
-                    let finalTooltip = `<b>${this.x}</b><br/>
-                            <span style=\"color:${this.color}\">●</span> ${seriesLabel}: <b>${costDisplay}</b>${certText}`;
+                    // Build tooltip content based on toggle selection
+                    let tooltipContent = '';
                     
-                    return finalTooltip;
+                    // Get current toggle selection
+                    const selectedView = $('input[name="tooltip-view"]:checked').attr('id').replace('view-', '');
+                    
+                    switch(selectedView) {
+                        case 'cost':
+                            // Show only Amount Due
+                            tooltipContent = `<b>${this.x}</b><br/>
+                                <span style=\"color:${this.color}\">●</span> ${seriesLabel}: <b>${costDisplay}</b>`;
+                            break;
+                            
+                        case 'certificates':
+                            // Show only Required Certificates (if available)
+                            if (certText) {
+                                tooltipContent = `<b>${this.x}</b><br/>
+                                    <span style=\"color:${this.color}\">●</span> Required Certificates: <b>${certText.replace('<br/><span style=\"color:#888\">Required Certificates:</span> ', '')}</b>`;
+                            } else {
+                                // Fallback to cost if no certificates available
+                                tooltipContent = `<b>${this.x}</b><br/>
+                                    <span style=\"color:${this.color}\">●</span> ${seriesLabel}: <b>${costDisplay}</b>`;
+                            }
+                            break;
+                            
+                        case 'both':
+                        default:
+                            // Show both Amount Due and Required Certificates
+                            tooltipContent = `<b>${this.x}</b><br/>
+                                <span style=\"color:${this.color}\">●</span> ${seriesLabel}: <b>${costDisplay}</b>${certText}`;
+                            break;
+                    }
+                    
+                    return tooltipContent;
                 }
             },
             legend: {

--- a/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py
+++ b/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py
@@ -247,34 +247,87 @@ def get_cbam_report_data(cbam_reports=None, start=0, page_length=50, from_year=N
     for q in all_quarters:
         if q not in quarter_totals:
             quarter_totals[q] = {"actual": 0, "standard": 0, "is_forecast": True}
+    
     # Create chart data with quarter labels and separate actual/forecast series
     chart_categories = []
     actual_data = []
     forecast_data = []
     import calendar
+    ets_prices = []
+    
     for year in sorted(years_with_reports):
         year_quarters = [(year, q) for q in range(1, 5)]
-        # Calculate average of actuals for this year only
         actual_values = [quarter_totals[q]["actual"] for q in year_quarters if not quarter_totals[q]["is_forecast"] and quarter_totals[q]["actual"] is not None]
         avg_actual = sum(actual_values) / len(actual_values) if actual_values else 0
+        
         for q in year_quarters:
             _, quarter = q
             last_month = {1: 3, 2: 6, 3: 9, 4: 12}[quarter]
             month_name = calendar.month_name[last_month]
             category_label = f"{month_name} {year}"
             chart_categories.append(category_label)
+            
+            # Get ETS price from the data rows for this quarter
+            ets_price = None
+            for row in data:
+                if row.get("year") == year and row.get("quarter") == quarter:
+                    ets_price = row.get("ets_price")
+                    if ets_price is not None:
+                        break
+            
+            # If no ETS price found for this quarter, use fallback logic
+            if ets_price is None:
+                # First try: look for ETS price in previous quarters of the same year
+                fallback_ets_price = None
+                for prev_q in year_quarters:
+                    if prev_q < q:  # Only look at previous quarters
+                        for row in data:
+                            if row.get("year") == year and row.get("quarter") == prev_q[1]:
+                                fallback_ets_price = row.get("ets_price")
+                                if fallback_ets_price is not None:
+                                    break
+                        if fallback_ets_price is not None:
+                            break
+                
+                # Second try: if still no price, look in previous years
+                if fallback_ets_price is None:
+                    for prev_year in sorted(years_with_reports):
+                        if prev_year < year:
+                            for row in data:
+                                if row.get("year") == prev_year:
+                                    fallback_ets_price = row.get("ets_price")
+                                    if fallback_ets_price is not None:
+                                        break
+                            if fallback_ets_price is not None:
+                                break
+                
+                # Use fallback price if found
+                if fallback_ets_price is not None:
+                    ets_price = fallback_ets_price
+            
+            ets_prices.append(ets_price)
+            
             if quarter_totals[q]["is_forecast"]:
                 actual_data.append(None)
                 forecast_data.append(avg_actual)
             else:
                 actual_data.append(quarter_totals[q]["actual"])
                 forecast_data.append(None)
+    
+    # Ensure ets_prices array covers ALL chart categories (including overlays)
+    # If there are more categories than ETS prices, extend the array with fallback values
+    while len(ets_prices) < len(chart_categories):
+        # Use the last available ETS price as fallback for additional categories
+        last_ets_price = ets_prices[-1] if ets_prices else None
+        ets_prices.append(last_ets_price)
+    
     chart_data = {
         "categories": chart_categories,
         "series": [
             {"name": "Actual Cost", "data": actual_data},
             {"name": "Forecast", "data": forecast_data},
         ],
+        "ets_prices": ets_prices,
         "year_due_dates": year_due_dates
     }
 


### PR DESCRIPTION
**Issue:** https://git.phamos.eu/gallehr/cbam/-/work_items/595
**Parent Issue:** https://git.phamos.eu/gallehr/cbam/-/issues/594


**## 🎯 Overview**
Enhanced the Financial Exposure Forecast chart with a user-friendly toggle switch that allows users to customize tooltip information display.

**## ✨ New Features**

- **Toggle Switch Above Chart**: Three view options for tooltip content
  - 💰 **Amount Due in €**: Shows only cost values
  - 🏆 **Required Certificates**: Shows only certificate counts (cost ÷ ETS price)
  - 👁️ **Both Views**: Shows both cost and certificates


![Aug-13-2025 15-09-20](https://github.com/user-attachments/assets/cf105271-9a04-457d-aed0-e2d93ae34ca8)
