### PR TITLE
gallehr/cbam#600: updated ets card and filter

### DIFF
--- a/cbam/cbam/page/various_cost_comparisons/filter.js
+++ b/cbam/cbam/page/various_cost_comparisons/filter.js
@@ -1,12 +1,23 @@
 frappe.provide('cbam');
- 
+
 /**
  * Create a filter control and append to the parent selector.
  */
 cbam.create_filter = function(label, fieldtype, fieldname, parentSelector, options = null, link_to = null, default_val = null) {
     const df = { label, fieldname, fieldtype, options, default: default_val };
     if (link_to) df.options = link_to;
-    const control = frappe.ui.form.make_control({ parent: $('<div class="col mb-2"></div>').appendTo(parentSelector), df });
+    
+    // Determine appropriate column class based on parent selector
+    let columnClass = 'col mb-2';
+    if (parentSelector === '#filter-section-group-2') {
+        // For group 2 (Year, ETS Price Type) - use slightly wider width
+        columnClass = 'col-md-4 col-lg-3 mb-2';
+    } else if (parentSelector === '#filter-section-group-1') {
+        // For group 1 (CN Code, Supplier, Article Number, Reporting Period) - use slightly wider width
+        columnClass = 'col-md-5 col-lg-4 mb-2';
+    }
+    
+    const control = frappe.ui.form.make_control({ parent: $('<div class="' + columnClass + '"></div>').appendTo(parentSelector), df });
     control.refresh();
     if (default_val !== undefined && default_val !== null && default_val !== "") {
         control.set_value(default_val);
@@ -25,7 +36,7 @@ cbam.setup_filter_clear_buttons = function(filters, load_report_table) {
         load_report_table(true);
     });
     $('#clear-group-2').on('click', () => {
-        ['ets_price_type', 'year', 'month', 'ets_price'].forEach(key => {
+        ['ets_price_type', 'year', 'month'].forEach(key => {
             if (filters[key]) {
                 if (filters[key].df.fieldtype === 'MultiSelectList') {
                     filters[key].set_value([]);
@@ -42,15 +53,7 @@ cbam.setup_filter_clear_buttons = function(filters, load_report_table) {
  * Setup listeners for filter changes.
  */
 cbam.setup_filter_listeners = function(filters, load_report_table, update_stat_card_values, refresh_ets_price_options) {
-    // Set initial state for year filter based on ETS Price Type
-    const initialEtsPriceType = filters.ets_price_type.get_value();
-    if (initialEtsPriceType === 'Future') {
-        if (filters.year && filters.year.$wrapper) {
-            const yearInput = filters.year.$wrapper.find('input');
-            yearInput.prop('disabled', true);
-            yearInput.addClass('disabled');
-        }
-    }
+    // Group 1 filters - only trigger table reload
     ['cn_code', 'supplier', 'article_number', 'reporting_period'].forEach(key => {
         const ctrl = filters[key];
         if (ctrl) {
@@ -59,42 +62,29 @@ cbam.setup_filter_listeners = function(filters, load_report_table, update_stat_c
             };
         }
     });
-    ['ets_price_type', 'year', 'month', 'ets_price'].forEach(key => {
+    
+    // Group 2 filters - trigger stat card updates and ETS price refresh
+    ['ets_price_type', 'year', 'month'].forEach(key => {
         const ctrl = filters[key];
         if (ctrl) {
             ctrl.df.onchange = () => {
-                // Handle year filter disable/enable for Future type
-                if (key === 'ets_price_type') {
-                    const etsPriceType = filters.ets_price_type.get_value();
-                    if (etsPriceType === 'Future') {
-                        // Disable year filter
-                        if (filters.year && filters.year.$wrapper) {
-                            const yearInput = filters.year.$wrapper.find('input');
-                            yearInput.prop('disabled', true);
-                            yearInput.addClass('disabled');
-                        }
-                    } else {
-                        // Enable year filter
-                        if (filters.year && filters.year.$wrapper) {
-                            const yearInput = filters.year.$wrapper.find('input');
-                            yearInput.prop('disabled', false);
-                            yearInput.removeClass('disabled');
-                        }
-                    }
-                }
-                
                 const selected_filters = {
                     ets_price_type: filters.ets_price_type.get_value(),
                     year: filters.year.get_value(),
-                    ets_price: filters.ets_price.get_value(),
                 };
+                
+                // Update stat cards
                 update_stat_card_values(key, selected_filters);
+                
+                // Refresh ETS price if relevant filters changed
                 if (key === 'ets_price_type' || key === 'year') {
                     refresh_ets_price_options(
                         filters.ets_price_type.get_value(),
                         filters.year.get_value()
                     );
                 }
+                
+                // Reload table
                 load_report_table(true);
             };
         }
@@ -106,111 +96,162 @@ cbam.setup_filter_listeners = function(filters, load_report_table, update_stat_c
  */
 cbam.get_all_selected_filters = function(filters) {
     const selected_filters = {};
-            ['cn_code', 'supplier', 'article_number', 'reporting_period'].forEach(key => {
-                selected_filters[key] = filters[key]?.get_value?.() || [];
-            });
-            ['ets_price_type', 'year', 'ets_price'].forEach(key => {
-                selected_filters[key] = filters[key]?.get_value?.() || '';
-            });
-            // Special handling for CBAM Factor - use data-original-value if available
-            let cbamFactorElement = $('[data-stat="cbam-factor"]');
-            let cbamFactor = 0;
-            if (cbamFactorElement.attr('data-original-value')) {
-                cbamFactor = parseFloat(cbamFactorElement.attr('data-original-value')) || 0;
+    
+    // Collect filter values
+    ['cn_code', 'supplier', 'article_number', 'reporting_period'].forEach(key => {
+        selected_filters[key] = filters[key]?.get_value?.() || [];
+    });
+    
+    ['ets_price_type', 'year'].forEach(key => {
+        const value = filters[key]?.get_value?.();
+        console.log(`Filter ${key} value:`, value, 'Type:', typeof value);
+        selected_filters[key] = value || '';
+    });
+    
+    // Get ETS Price value from the stat card display
+    const etsPriceValue = cbam.get_ets_price_from_stat_card();
+    selected_filters.ets_price = etsPriceValue;
+    
+    // Get other stat values
+    selected_filters.cbam_factor = cbam.get_stat_value('cbam-factor', true);
+    selected_filters.bench_mark = cbam.get_stat_value('bench-mark-emission-value');
+    selected_filters.emission_value = cbam.get_stat_value('standard-emission-value');
+    selected_filters.ets_price_value = etsPriceValue;
+    
+    console.log('Final selected_filters:', selected_filters);
+    return selected_filters;
+};
+
+/**
+ * Get ETS Price value from stat card with proper parsing.
+ */
+cbam.get_ets_price_from_stat_card = function() {
+    console.log('get_ets_price_from_stat_card called');
+    
+    const etsPriceElements = $('[data-stat="ets-price"]');
+    console.log(`Found ${etsPriceElements.length} elements with data-stat="ets-price":`);
+    
+    let finalValue = 0.0;
+    etsPriceElements.each(function(index) {
+        const element = $(this);
+        const elementText = element.text();
+        const elementSelector = element.prop('tagName') + (element.attr('class') ? '.' + element.attr('class').split(' ').join('.') : '');
+        
+        console.log(`Element ${index} (${elementSelector}): "${elementText}"`);
+        
+        if (index === 0) { // Use the first element for the actual value
+            if (!elementText || elementText === '--') {
+                console.log('Element text is empty or "--", returning 0.0');
+                finalValue = 0.0;
             } else {
-                cbamFactor = parseFloat(cbamFactorElement.text()) || 0;
+                // Extract numeric part from display value like "22 (2025)"
+                if (elementText.includes('(')) {
+                    const numericMatch = elementText.match(/^([\d.]+)/);
+                    if (numericMatch) {
+                        finalValue = parseFloat(numericMatch[1]) || 0.0;
+                        console.log('Extracted numeric ETS Price:', finalValue);
+                    } else {
+                        console.log('No numeric match found, returning 0.0');
+                        finalValue = 0.0;
+                    }
+                } else {
+                    finalValue = parseFloat(elementText) || 0.0;
+                    console.log('Parsed ETS Price directly:', finalValue);
+                }
             }
-            selected_filters.cbam_factor = cbamFactor;
-            selected_filters.bench_mark = parseFloat($('[data-stat="bench-mark-emission-value"]').text()) || 0;
-            selected_filters.emission_value = parseFloat($('[data-stat="standard-emission-value"]').text()) || 0;
-            selected_filters.ets_price_value = parseFloat($('[data-stat="ets-price"]').text()) || 0;
-            return selected_filters;
+        }
+    });
+    
+    console.log('Final ETS Price value returned:', finalValue);
+    return finalValue;
+};
+
+/**
+ * Get stat value from DOM with proper parsing.
+ */
+cbam.get_stat_value = function(statName, useOriginalValue = false) {
+    const element = $(`[data-stat="${statName}"]`);
+    if (!element.length) return 0.0;
+    
+    if (useOriginalValue && element.attr('data-original-value')) {
+        return parseFloat(element.attr('data-original-value')) || 0.0;
+    }
+    
+    return parseFloat(element.text()) || 0.0;
+};
+
+/**
+ * Update ETS Price stat card with new value.
+ */
+cbam.update_ets_price_stat_card = function(displayValue) {
+    console.log('update_ets_price_stat_card called with:', displayValue);
+    
+    const selectors = [
+        '[data-stat="ets-price"]',
+        '.stat-value[data-stat="ets-price"]'
+    ];
+    
+    let updatedCount = 0;
+    selectors.forEach(selector => {
+        const elements = $(selector);
+        console.log(`Selector "${selector}" found ${elements.length} elements:`, elements);
+        
+        elements.each(function(index) {
+            const element = $(this);
+            const oldValue = element.text();
+            element.text(displayValue);
+            console.log(`Updated element ${index}: "${oldValue}" → "${displayValue}"`);
+            updatedCount++;
+        });
+    });
+    
+    console.log(`Total elements updated: ${updatedCount}`);
+    
+    // Verify the update worked
+    setTimeout(() => {
+        const allElements = $('[data-stat="ets-price"]');
+        console.log('Verification - all ets-price elements after update:');
+        allElements.each(function(index) {
+            console.log(`Element ${index}: "${$(this).text()}"`);
+        });
+    }, 100);
 };
 
 /**
  * Refresh ETS Price options based on type and year.
  */
 cbam.refresh_ets_price_options = function(filters, ets_price_type, year) {
-    if (!ets_price_type) return;
-    
-    // For Future type, fetch all future prices regardless of year
-    if (ets_price_type === 'Future') {
-        const currentYear = new Date().getFullYear();
-        frappe.db.get_list('ETS Carbon Price', {
-            fields: ['name', 'price', 'price_year'],
-            filters: { ets_price_type: 'Future' },
-            order_by: 'price_year desc, price desc',
-            limit: 100,
-        }).then(res => {
-            const prices = res
-                .filter(row => {
-                    // Exclude current year prices for Future type
-                    return row.price_year > currentYear;
-                })
-                .map(row => {
-                    return {
-                        label: `${row.price} (${row.price_year})`,
-                        value: String(row.price),
-                        year: row.price_year
-                    };
-                });
-            
-            // Remove duplicates based on price AND year combination
-            const uniquePrices = [];
-            const seenCombinations = new Set();
-            prices.forEach(price => {
-                const combination = `${price.value}-${price.year}`;
-                if (!seenCombinations.has(combination)) {
-                    uniquePrices.push({
-                        label: price.label,
-                        value: price.value
-                    });
-                    seenCombinations.add(combination);
-                }
-            });
-            
-            filters.ets_price.df.options = uniquePrices;
-            filters.ets_price.refresh();
-            if (uniquePrices.length) {
-                filters.ets_price.set_value(uniquePrices[0].value);
-            }
-        }).catch(() => {
-            filters.ets_price.df.options = [];
-            filters.ets_price.refresh();
-        });
-    } else {
-        // For Actual/Prediction types, use the original logic with year filtering
-        if (!year) return;
-        frappe.db.get_list('ETS Carbon Price', {
-            fields: ['name', 'price', 'price_date'],
-            filters: { ets_price_type },
-            order_by: 'price_date desc',
-            limit: 100,
-        }).then(res => {
-            const prices = res
-                .filter(row => {
-                    const y = frappe.datetime.str_to_obj(row.price_date).getFullYear();
-                    return y == year;
-                })
-                .map(row => {
-                    let dateStr = '';
-                    if (row.price_date) {
-                        const d = frappe.datetime.str_to_obj(row.price_date);
-                        dateStr = ` (${d.getDate().toString().padStart(2, '0')}-${(d.getMonth()+1).toString().padStart(2, '0')}-${d.getFullYear()})`;
-                    }
-                    return {
-                        label: `${row.price}${dateStr}`,
-                        value: String(row.price)
-                    };
-                });
-            filters.ets_price.df.options = prices;
-            filters.ets_price.refresh();
-            if (prices.length) {
-                filters.ets_price.set_value(prices[0].value);
-            }
-        }).catch(() => {
-            filters.ets_price.df.options = [];
-            filters.ets_price.refresh();
-        });
+    if (!ets_price_type || !year) {
+        console.log('Missing required parameters for ETS price refresh');
+        return;
     }
+    
+    console.log('Refreshing ETS Price options for:', { ets_price_type, year });
+    
+    // Fetch latest price for the selected year and type
+    frappe.call({
+        method: 'cbam.cbam.page.various_cost_comparisons.various_cost_comparisons.get_latest_ets_price',
+        args: { year: year, ets_price_type: ets_price_type },
+        callback: function(r) {
+            console.log('Backend response:', r);
+            
+            if (r.message) {
+                const priceData = r.message;
+                const displayValue = `${priceData.price} (${priceData.price_year})`;
+                
+                console.log('Price data received:', priceData);
+                console.log('Display value for stat card:', displayValue);
+                
+                // Update the ETS Price stat card
+                cbam.update_ets_price_stat_card(displayValue);
+            } else {
+                console.log('No ETS price data found for year:', year, 'type:', ets_price_type);
+                cbam.update_ets_price_stat_card('0.0');
+            }
+        },
+        error: function(err) {
+            console.log('Error fetching ETS price:', err);
+            cbam.update_ets_price_stat_card('0.0');
+        }
+    });
 };

--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.js
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.js
@@ -32,6 +32,9 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
         cbam.setup_filter_clear_buttons(filters, load_report_table);
         cbam.setup_filter_listeners(filters, load_report_table, update_stat_card_values, (ets_price_type, year) => cbam.refresh_ets_price_options(filters, ets_price_type, year));
 
+        // Setup Year-ETS Price Type logic
+        setupYearEtsPriceTypeLogic(filters);
+
         // Pagination state
         let start = 0;
         let page_length = 50;
@@ -135,6 +138,95 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
             $('#export').prop('disabled', selected.length === 0);
         }
 
+        /**
+         * Setup Year-ETS Price Type field logic
+         */
+        function setupYearEtsPriceTypeLogic(filters) {
+            // Wait for page to fully load
+            setTimeout(() => {
+                // Find the year and ETS price type fields
+                const yearField = $('label:contains("Year")').closest('.form-group').find('input, select');
+                const etsPriceTypeField = $('label:contains("ETS Price Basis")').closest('.form-group').find('input, select');
+                
+                if (yearField.length > 0 && etsPriceTypeField.length > 0) {
+                    // Populate Future options with proper format
+                    const currentYear = new Date().getFullYear();
+                    const futureOptions = ['', 'Actual'];
+                    
+                    // Add Future option with generic format
+                    futureOptions.push('Future');
+                    
+                    // Update the ETS Price Type field options
+                    etsPriceTypeField.empty();
+                    futureOptions.forEach(option => {
+                        if (option === '') {
+                            etsPriceTypeField.append('<option value=""></option>');
+                        } else if (option === 'Actual') {
+                            etsPriceTypeField.append('<option value="Actual">Spot Price</option>');
+                        } else if (option === 'Future') {
+                            etsPriceTypeField.append('<option value="Future">Future (Dec)</option>');
+                        }
+                    });
+                    
+                    // Set default value to Actual (Spot Price)
+                    etsPriceTypeField.val('Actual');
+                    
+                    // Add change event listener to year field
+                    yearField.on('change', function() {
+                        const selectedYear = parseInt($(this).val());
+                        const currentYear = new Date().getFullYear();
+                        
+                        console.log('Year changed to:', selectedYear, 'Current year:', currentYear);
+                        
+                        if (selectedYear && selectedYear > currentYear) {
+                            // Future year: set ETS Price Type to Future and make read-only
+                            etsPriceTypeField.val('Future');
+                            etsPriceTypeField.prop('disabled', true);
+                        } else if (selectedYear && selectedYear == currentYear) {
+                            // Current year: make ETS Price Type editable and set to Actual (Spot Price)
+                            etsPriceTypeField.prop('disabled', false);
+                            etsPriceTypeField.val('Actual');
+                        } else {
+                            // Past year: make ETS Price Type editable and set to Actual (Spot Price)
+                            etsPriceTypeField.prop('disabled', false);
+                            etsPriceTypeField.val('Actual');
+                        }
+                        
+                        // Trigger filter change to update ETS Price
+                        if (selectedYear) {
+                            const selectedEtsType = etsPriceTypeField.val();
+                            console.log('Triggering ETS price update for year:', selectedYear, 'type:', selectedEtsType);
+                            if (selectedEtsType) {
+                                // Manually trigger the filter change to update ETS Price
+                                cbam.refresh_ets_price_options(filters, selectedEtsType, selectedYear);
+                            }
+                        }
+                    });
+                    
+                    // Add change event listener to ETS Price Type field
+                    etsPriceTypeField.on('change', function() {
+                        const selectedEtsType = $(this).val();
+                        console.log('ETS Price Basis changed to:', selectedEtsType);
+                        
+                        // Ensure Year field is never read-only
+                        yearField.prop('disabled', false);
+                        yearField.prop('readonly', false);
+                        
+                        // Update ETS Price when ETS Price Type changes
+                        const selectedYear = parseInt(yearField.val());
+                        console.log('Triggering ETS price update for year:', selectedYear, 'type:', selectedEtsType);
+                        if (selectedYear && selectedEtsType) {
+                            // Manually trigger the filter change to update ETS Price
+                            cbam.refresh_ets_price_options(filters, selectedEtsType, selectedYear);
+                        }
+                    });
+                    
+                    // Apply initial logic
+                    yearField.trigger('change');
+                }
+            }, 1000);
+        }
+
 
         /**
          * Render the main page layout.
@@ -201,9 +293,12 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                 article_number: cbam.create_filter('Article Number', 'MultiSelectList', 'article_number', '#filter-section-group-1', []),
                 reporting_period: cbam.create_filter('Reporting Period', 'MultiSelectList', 'reporting_period', '#filter-section-group-1', []),
                 year: cbam.create_filter('Year', 'Link', 'year', '#filter-section-group-2', null, 'Year', currentYear),
-                ets_price_type: cbam.create_filter('ETS Price Type', 'Select', 'ets_price_type', '#filter-section-group-2', ['', 'Actual', 'Future'], null, 'Actual'),
-                ets_price: cbam.create_filter('ETS Price', 'Select', 'ets_price', '#filter-section-group-2', []),
+                ets_price_type: cbam.create_filter('ETS Price Basis', 'Select', 'ets_price_type', '#filter-section-group-2', ['', 'Actual', 'Future'], null, 'Actual'),
             };
+
+            console.log('Filters created:', filters);
+            console.log('ETS Price Type filter:', filters.ets_price_type);
+            console.log('Year filter:', filters.year);
 
             // CN Code: no dependencies
             filters.cn_code.df.get_data = function(txt) {
@@ -255,14 +350,19 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
         function update_stat_card_values(key, filters) {
             if (key === 'ets_price') {
                 $('.stat-value[data-stat="ets-price"]').text(filters.ets_price || 0.0);
+                // After updating ETS Price, reload table and chart with new value
+                console.log('ETS Price updated, reloading table and chart...');
+                load_report_table(true, filters);
                 return;
             }
+            
             clear_stats();
             frappe.call({
                 method: 'cbam.cbam.page.various_cost_comparisons.various_cost_comparisons.get_cards_value',
                 args: { filters },
                 callback: function (r) {
                     if (!r.message) return;
+                    
                     const updated_values = {
                         'standard-emission-value': r.message.emission_value || 0.0,
                         'bench-mark-emission-value': r.message.bench_mark || 0.0,
@@ -270,19 +370,26 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                         'ets-price': r.message.ets_price || 0.0,
                         'year': filters.year || frappe.datetime.get_today().split('-')[0],
                     };
+                    
                     Object.entries(updated_values).forEach(([key, val]) => {
                         let displayValue = val;
+                        
                         // Special formatting for CBAM Factor - convert to percentage
                         if (key === 'cbam-factor' && val !== 0.0 && val !== null && val !== undefined) {
                             const numValue = parseFloat(val);
                             if (!isNaN(numValue)) {
                                 displayValue = (numValue * 100).toFixed(0) + '%';
                                 // Store original value in data attribute for calculations
-                                $('.stat-value[data-stat="' + key + '"]').attr('data-original-value', val);
+                                $(`.stat-value[data-stat="${key}"]`).attr('data-original-value', val);
                             }
                         }
-                        $('.stat-value[data-stat="' + key + '"]').text(displayValue);
+                        
+                        $(`.stat-value[data-stat="${key}"]`).text(displayValue);
                     });
+                    
+                    // After updating stat cards, reload table and chart with new values
+                    console.log('Stat cards updated, reloading table and chart...');
+                    load_report_table(true, filters);
                 },
                 error: function () {
                     clear_stats();
@@ -290,10 +397,16 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
             });
         }
 
-        /**
+        /** 
          * Clear and render stat cards with default values.
          */
         function clear_stats() {
+            // Check if stat cards already exist to prevent duplication
+            if ($('#compact-stat-row .stat-card').length > 0) {
+                console.log('Stat cards already exist, skipping creation');
+                return;
+            }
+            
             const compact_stats = [
                 { label: 'Standard Emission Value', value: '--', display_label: 'Standard Emissions Factor [t CO2/t Product]' },
                 { label: 'Bench Mark Emission Value', value: '--', display_label: 'Benchmark [t CO2/t Product]' },
@@ -306,6 +419,7 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                 const displayLabel = stat.display_label || stat.label;
                 $('#compact-stat-row').append(`<div class='col mb-2'>${render_compact_card_with_data_stat(displayLabel, stat.value, stat.label)}</div>`);
             });
+            console.log('Stat cards created:', $('#compact-stat-row .stat-card').length);
         }
 
         /**

--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
@@ -1,6 +1,7 @@
 import frappe
 import json
 from datetime import datetime
+import re
 
 @frappe.whitelist()
 def get_report_data(filters=None, selected_filters=None, start=0, page_length=50):
@@ -51,7 +52,7 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
         page_length = int(page_length)
     except Exception:
         page_length = 50
-
+ 
     # Merge selected_filters into filters, but only non-empty values
     for key, value in selected_filters.items():
         if value is not None and value != '' and value != []:
@@ -73,7 +74,18 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
     cbam_factor = float(selected_filters.get('cbam_factor', 0.0) or 0.0)
     bench_mark = float(selected_filters.get('bench_mark', 0.0) or 0.0)
     emission_value = float(selected_filters.get('emission_value', 0.0) or 0.0)
-    ets_carbon_price = float(selected_filters.get('ets_price_value', 0.0) or selected_filters.get('ets_price', 0.0) or 0.0)
+    
+    # Handle ETS price value safely - extract numeric part if it contains display text
+    ets_price_raw = selected_filters.get('ets_price_value', 0.0) or selected_filters.get('ets_price', 0.0) or 0.0
+    if isinstance(ets_price_raw, str) and '(' in ets_price_raw:
+        # Extract numeric part from display value like "22 (2025)"
+        numeric_match = re.match(r'^([\d.]+)', ets_price_raw)
+        if numeric_match:
+            ets_price_raw = float(numeric_match.group(1))
+        else:
+            ets_price_raw = 0.0
+    
+    ets_carbon_price = float(ets_price_raw) if ets_price_raw else 0.0
 
     # Count total rows for pagination
     total_count = get_count(where_sql, where_sql_eg)
@@ -243,6 +255,25 @@ def get_cards_value(filters=None):
     import json
 
     filters = json.loads(filters) if filters else {}
+    
+    # Map frontend display names to backend values
+    ets_price_type_mapping = {
+        'Spot Price': 'Actual',
+        'Future': 'Future'
+    }
+    
+    # Provide default values for missing keys
+    year = filters.get('year', datetime.now().year) # Fixed datetime access
+    ets_price_type = filters.get('ets_price_type', 'Spot Price')  # Default to Spot Price if not provided
+    
+    # Convert frontend display name to backend value
+    backend_ets_price_type = ets_price_type_mapping.get(ets_price_type, 'Actual')
+    
+    # Create a safe parameters dict for SQL
+    sql_params = {
+        'year': year,
+        'ets_price_type': backend_ets_price_type
+    }
 
     sql = """
         SELECT 
@@ -256,12 +287,13 @@ def get_cards_value(filters=None):
         LEFT JOIN `tabStandard Emission Value` sev 
             ON sev.year = %(year)s
         LEFT JOIN `tabETS Carbon Price` ecp 
-            ON YEAR(ecp.price_date) = %(year)s AND ecp.ets_price_type = %(ets_price_type)s
+            ON ecp.price_year = %(year)s AND ecp.ets_price_type = %(ets_price_type)s
         WHERE cf.year = %(year)s
+
         LIMIT 1
     """
 
-    result = list(frappe.db.sql(sql, filters, as_dict=True))
+    result = list(frappe.db.sql(sql, sql_params, as_dict=True))
     return result[0] if result else {}
 
 
@@ -339,3 +371,57 @@ def get_filter_options(txt=None, filter_type=None, cn_code=None, supplier=None):
     eg_options = fetch_external_good_options(filter_type, txt, declarants, cn_code_list, supplier_list)
     g_options = fetch_good_options(filter_type, txt, declarants, cn_code_list, supplier_list)
     return merge_and_format_options(eg_options, g_options)
+
+
+@frappe.whitelist()
+def get_latest_ets_price(year=None, ets_price_type=None):
+    """Get the latest available ETS price for given year and type"""
+    print(f"get_latest_ets_price called with year={year}, ets_price_type={ets_price_type}")
+    
+    if not year or not ets_price_type:
+        print("Missing year or ets_price_type")
+        return None
+    
+    # Convert year to integer if it's a string
+    try:
+        year = int(year)
+    except (ValueError, TypeError):
+        print(f"Invalid year format: {year}")
+        return None
+    
+    # Use different ordering logic based on ETS price type
+    if ets_price_type == 'Actual':
+        # For Actual prices: order by price_date, then by modified to handle same-date ties
+        order_clause = "ORDER BY price_date DESC, modified DESC"
+        print(f"Using Actual ordering: {order_clause}")
+    else:
+        # For Future prices: order by creation date to get most recently announced/created price
+        order_clause = "ORDER BY modified DESC"
+        print(f"Using Future ordering: {order_clause}")
+    
+    sql = f"""
+        SELECT 
+            price,
+            price_date,
+            ets_price_type,
+            price_year
+        FROM `tabETS Carbon Price`
+        WHERE price_year = %(year)s 
+        AND ets_price_type = %(ets_price_type)s
+        {order_clause}
+        LIMIT 1
+    """
+    
+    sql_params = {"year": year, "ets_price_type": ets_price_type}
+    print(f"SQL query: {sql}")
+    print(f"SQL params: {sql_params}")
+    
+    result = frappe.db.sql(sql, sql_params, as_dict=True)
+    print(f"SQL result: {result}")
+    
+    if result:
+        print(f"Returning: {result[0]}")
+        return result[0]
+    else:
+        print("No result found")
+        return None


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/600
parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/594
 
  1. Year-ETS Price Type Logic Enhancement
     
     The most substantial change is the addition of intelligent logic for handling Year and ETS Price Type fields:
     - **Automatic ETS Price Type Selection:** When a user selects a future year, the system automatically sets ETS Price Type to "Future" and makes it read-only
     - **Dynamic Field Behavior:** For current/past years, ETS Price Type remains editable and defaults to "Actual" (Spot Price)
     - **Smart Labeling:** The ETS Price Type field now shows user-friendly labels:
       - "Actual" → "Spot Price"
       - "Future" → "Future (Dec)"

  2. ETS Price Integration & Updates

     - **Backend Integration:** New get_latest_ets_price() method that intelligently selects the most recent price based on type:
        - Actual prices: ordered by price date (most recent first)
        - Future prices: ordered by creation/modification date
        
     - **Dynamic Stat Card Updates:** ETS Price stat card updates automatically when filters change


![Aug-14-2025 17-44-56](https://github.com/user-attachments/assets/ddcb1e11-ad3f-477c-bc6f-e0439dc2f6c2)
