### PR TITLE
gallehr/cbam#600: Various Cost Comparison Chart change requirements

### DIFF
--- a/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.json
+++ b/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.json
@@ -32,7 +32,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "ETS price Type",
-   "options": "\nActual\nPrediction\nFuture",
+   "options": "\nSpot Price\nFuture (Dec)",
    "set_only_once": 1
   },
   {
@@ -58,12 +58,10 @@
    "options": "ETS Carbon Price Source"
   },
   {
-   "depends_on": "eval:doc.ets_price_type != \"Future\"",
    "fieldname": "price_date",
    "fieldtype": "Date",
    "in_list_view": 1,
-   "label": "Price Date",
-   "set_only_once": 1
+   "label": "Price Date"
   },
   {
    "fieldname": "column_break_moht",
@@ -95,7 +93,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-22 07:56:47.792610",
+ "modified": "2025-08-19 13:32:44.461538",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "ETS Carbon Price",

--- a/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.py
+++ b/cbam/cbam/doctype/ets_carbon_price/ets_carbon_price.py
@@ -5,7 +5,8 @@ import frappe
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
 from frappe.sessions import datetime
-from frappe.utils import today, formatdate
+from frappe.utils import today, formatdate, getdate
+
 
 class ETSCarbonPrice(Document):
 	
@@ -13,38 +14,34 @@ class ETSCarbonPrice(Document):
 		if not self.ets_price_type:
 			frappe.throw("ETS Price Type (Actual or Prediction or Future) is required.")
 
-		if self.ets_price_type == "Future":
+		if self.ets_price_type == "Future (Dec)":
 			if not self.price_year:
-				frappe.throw("ETS Carbon Price Year is required for Future type.")
+				frappe.throw("ETS Carbon Price Year is required for Future (Dec) type.")
 
 			# Use Frappe's counter mechanism with date series
-			creation_date_str = formatdate(self.creation, "yyyy-MM-dd")
-			counter_prefix = f"ETS-{creation_date_str}-.####"
+			price_date_str = formatdate(self.price_date, "yyyy-MM-dd")
+			counter_prefix = f"ETS-{price_date_str}-.####"
 			counter_id = make_autoname(counter_prefix)
-			self.creation_date = self.creation or today()
+			self.price_date_date = self.price_date or today()
 			self.name = f"{counter_id}-F-{self.price_year}"
 			return
 
 		if not self.price_date:
 			frappe.throw("ETS Carbon Price Date is required.")
 
-		# Map Actual / Prediction to A / P
-		type_code = "A" if self.ets_price_type == "Actual" else "P"
+		# Map Spot Price / Prediction to A / P
+		type_code = "A" if self.ets_price_type == "Spot Price" else "P"
 		price_date_str = formatdate(self.price_date, "yyyy-MM-dd")
 		# Use Frappe's counter mechanism with date series
-		creation_date_str = formatdate(self.creation, "yyyy-MM-dd")
-		counter_prefix = f"ETS-{creation_date_str}-.####"
+		price_date_str = formatdate(self.price_date, "yyyy-MM-dd")
+		counter_prefix = f"ETS-{price_date_str}-.####"
 		counter_id = make_autoname(counter_prefix)
-		self.creation_date = self.creation or today()
+		self.price_date = self.price_date or today()
 		self.name = f"{counter_id}-{type_code}-{price_date_str}"
 
 	def validate(self):
-		if self.ets_price_type == "Future":
-			self.price_date = None
-		elif self.ets_price_type in ["Actual", "Prediction"]:
-			# Set price_year to the year from price_date
-			if self.price_date:
-				from frappe.utils import getdate
-				self.price_year = str(getdate(self.price_date).year)
+		# Set price_year to the year from price_date
+		if self.price_date and not self.price_year:
+			self.price_year = str(getdate(self.price_date).year)
 
 		

--- a/cbam/cbam/page/ets_price_dashboard/ets_price_dashboard.js
+++ b/cbam/cbam/page/ets_price_dashboard/ets_price_dashboard.js
@@ -187,8 +187,8 @@ frappe.pages['ets-price-dashboard'].on_page_load = function(wrapper) {
                 return false;
             }
 
-            // If the row's type is 'Future', include it regardless of the date range.
-            if (row.ets_price_type === 'Future') {
+            // If the row's type is 'Future (Dec)', include it regardless of the date range.
+            if (row.ets_price_type === 'Future (Dec)') {
                 return true;
             }
 
@@ -217,13 +217,13 @@ frappe.pages['ets-price-dashboard'].on_page_load = function(wrapper) {
         const etsTypes = etsPriceTypeFilter.get_value ? etsPriceTypeFilter.get_value() : [];
         let filters = {};
 
-        if (etsTypes.includes("Future")) {
-            // If both 'Actual' and 'Future' are selected, fetch both
-            if (etsTypes.includes("Actual")) {
-                filters = { ets_price_type: ["in", ["Actual", "Future"]] };
+        if (etsTypes.includes("Future (Dec)")) {
+            // If both 'Spot Price' and 'Future (Dec)' are selected, fetch both
+            if (etsTypes.includes("Spot Price")) {
+                filters = { ets_price_type: ["in", ["Spot Price", "Future (Dec)"]] };
             } else {
-                // Only fetch all 'Future' records, ignore date filters
-                filters = { ets_price_type: ["=", "Future"] };
+                // Only fetch all 'Future (Dec)' records, ignore date filters
+                filters = { ets_price_type: ["=", "Future (Dec)"] };
             }
         } else {
             // Use current date and type filters
@@ -335,9 +335,9 @@ frappe.pages['ets-price-dashboard'].on_page_load = function(wrapper) {
     }
 
     function renderChart(data) {
-        // Standard chart data: dated points for 'Actual' type only
+        // Standard chart data: dated points for 'Spot Price' type only
         const chartData = data
-            .filter(row => row.ets_price_type === 'Actual' && row.price_date && row.price)
+            .filter(row => row.ets_price_type === 'Spot Price' && row.price_date && row.price)
             .map(row => [
                 new Date(row.price_date).getTime(),
                 Number(row.price)
@@ -347,9 +347,9 @@ frappe.pages['ets-price-dashboard'].on_page_load = function(wrapper) {
         $('#ets-price-chart').css('min-width', '');
         // Always use allData for average-per-year series
         const avgYearSeries = getAveragePricePerYearSeries(allData);
-        // Determine if 'Future' is selected in the filter
+        // Determine if 'Future (Dec)' is selected in the filter
         const etsTypes = etsPriceTypeFilter.get_value ? etsPriceTypeFilter.get_value() : [];
-        const showFutureAvg = etsTypes.includes("Future");
+        const showFutureAvg = etsTypes.includes("Future (Dec)");
         // If no dated chart data, but price_year data exists, show average price per year as points
         let series = [];
         if (chartData.length === 0) {

--- a/cbam/cbam/page/ets_price_dashboard/ets_price_dashboard.py
+++ b/cbam/cbam/page/ets_price_dashboard/ets_price_dashboard.py
@@ -9,8 +9,8 @@ def get_table_data(doctype, fields, filters=None, start=0, page_length=50):
     start = int(start or 0)
     page_length = int(page_length or 50)
 
-    # Only fetch rows where ets_price_type is 'Actual' or 'Future'
-    filters["ets_price_type"] = ["in", ["Actual", "Future"]]
+    # Only fetch rows where ets_price_type is 'Spot Price' or 'Future (Dec)'
+    filters["ets_price_type"] = ["in", ["Spot Price", "Future (Dec)"]]
 
     data = frappe.get_all(doctype, fields=fields, filters=filters, start=start, page_length=page_length, order_by="price_date desc")
 

--- a/cbam/cbam/page/various_cost_comparisons/chart.js
+++ b/cbam/cbam/page/various_cost_comparisons/chart.js
@@ -29,7 +29,6 @@ cbam.get_chart_data = function get_chart_data(data, per_tonne = false) {
     };
 }
 
-
 cbam.update_chart = function update_chart(chart_data) {
     $('#chart-section').empty();
 
@@ -38,26 +37,10 @@ cbam.update_chart = function update_chart(chart_data) {
         return;
     }
 
-    // Custom: Concatenate article and supplier for x-axis labels if available
+    // Use chart labels directly
     let labels = chart_data.labels;
-    let label_map = {};
-    if (chart_data.articles && chart_data.suppliers && Array.isArray(chart_data.articles) && Array.isArray(chart_data.suppliers)) {
-        labels = chart_data.articles.map((article, idx) => {
-            const supplier = chart_data.suppliers[idx] || '';
-            const label = `${article} (${supplier})`;
-            label_map[idx] = label;
-            return label;
-        });
-    } else {
-        labels = chart_data.labels;
-        labels.forEach((l, idx) => { label_map[idx] = l; });
-    }
 
-    // Highcharts integration: create a scrollable container and chart div
-    //const minWidth = Math.max(600, labels.length * 80); // 80px per label as a heuristic
-    //$('#chart-section').append('<div id="highchart-scroll-inner" style="overflow-x: auto; width: 100%;"><div id="highchart-bar" style="min-width: ' + minWidth + 'px; max-height: 350px;"></div></div>');
-
-    // Highcharts integration: create chart div without scroll
+    // Create chart div
     $('#chart-section').append('<div id="highchart-bar" style="width: 100%; height: 350px;"></div>');
 
     function renderHighChart() {
@@ -79,7 +62,7 @@ cbam.update_chart = function update_chart(chart_data) {
                 }
             },
             yAxis: {
-                title: { text: __('Costs [€]') },
+                title: { text: __('Cost [€]') },
                 min: 0
             },
             legend: { align: 'center', verticalAlign: 'bottom', layout: 'horizontal' },

--- a/cbam/cbam/page/various_cost_comparisons/filter.js
+++ b/cbam/cbam/page/various_cost_comparisons/filter.js
@@ -10,11 +10,11 @@ cbam.create_filter = function(label, fieldtype, fieldname, parentSelector, optio
     // Determine appropriate column class based on parent selector
     let columnClass = 'col mb-2';
     if (parentSelector === '#filter-section-group-2') {
-        // For group 2 (Year, ETS Price Type) - use slightly wider width
-        columnClass = 'col-md-4 col-lg-3 mb-2';
+        // For group 2 (Year, ETS Price Type) - use smaller width to prevent overlap
+        columnClass = 'col-4 mb-2';
     } else if (parentSelector === '#filter-section-group-1') {
-        // For group 1 (CN Code, Supplier, Article Number, Reporting Period) - use slightly wider width
-        columnClass = 'col-md-5 col-lg-4 mb-2';
+        // For group 1 (CN Code, Supplier, Article Number, Reporting Period) - use compact width for one line
+        columnClass = 'col-3 mb-2';
     }
     
     const control = frappe.ui.form.make_control({ parent: $('<div class="' + columnClass + '"></div>').appendTo(parentSelector), df });
@@ -104,7 +104,6 @@ cbam.get_all_selected_filters = function(filters) {
     
     ['ets_price_type', 'year'].forEach(key => {
         const value = filters[key]?.get_value?.();
-        console.log(`Filter ${key} value:`, value, 'Type:', typeof value);
         selected_filters[key] = value || '';
     });
     
@@ -114,11 +113,13 @@ cbam.get_all_selected_filters = function(filters) {
     
     // Get other stat values
     selected_filters.cbam_factor = cbam.get_stat_value('cbam-factor', true);
-    selected_filters.bench_mark = cbam.get_stat_value('bench-mark-emission-value');
-    selected_filters.emission_value = cbam.get_stat_value('standard-emission-value');
+    
+    // Get bench_mark and emission_value from backend since stat cards were removed
+    // These will be fetched by the backend when get_report_data is called
+    selected_filters.bench_mark = 0.0; // Will be fetched from backend
+    selected_filters.emission_value = 0.0; // Will be fetched from backend
     selected_filters.ets_price_value = etsPriceValue;
     
-    console.log('Final selected_filters:', selected_filters);
     return selected_filters;
 };
 
@@ -126,43 +127,24 @@ cbam.get_all_selected_filters = function(filters) {
  * Get ETS Price value from stat card with proper parsing.
  */
 cbam.get_ets_price_from_stat_card = function() {
-    console.log('get_ets_price_from_stat_card called');
-    
     const etsPriceElements = $('[data-stat="ets-price"]');
-    console.log(`Found ${etsPriceElements.length} elements with data-stat="ets-price":`);
     
     let finalValue = 0.0;
     etsPriceElements.each(function(index) {
         const element = $(this);
         const elementText = element.text();
-        const elementSelector = element.prop('tagName') + (element.attr('class') ? '.' + element.attr('class').split(' ').join('.') : '');
-        
-        console.log(`Element ${index} (${elementSelector}): "${elementText}"`);
         
         if (index === 0) { // Use the first element for the actual value
             if (!elementText || elementText === '--') {
-                console.log('Element text is empty or "--", returning 0.0');
                 finalValue = 0.0;
             } else {
-                // Extract numeric part from display value like "22 (2025)"
-                if (elementText.includes('(')) {
-                    const numericMatch = elementText.match(/^([\d.]+)/);
-                    if (numericMatch) {
-                        finalValue = parseFloat(numericMatch[1]) || 0.0;
-                        console.log('Extracted numeric ETS Price:', finalValue);
-                    } else {
-                        console.log('No numeric match found, returning 0.0');
-                        finalValue = 0.0;
-                    }
-                } else {
-                    finalValue = parseFloat(elementText) || 0.0;
-                    console.log('Parsed ETS Price directly:', finalValue);
-                }
+                // Parse numeric value, removing Euro symbol if present
+                const cleanText = elementText.replace('€', '').trim();
+                finalValue = parseFloat(cleanText) || 0.0;
             }
         }
     });
     
-    console.log('Final ETS Price value returned:', finalValue);
     return finalValue;
 };
 
@@ -184,37 +166,19 @@ cbam.get_stat_value = function(statName, useOriginalValue = false) {
  * Update ETS Price stat card with new value.
  */
 cbam.update_ets_price_stat_card = function(displayValue) {
-    console.log('update_ets_price_stat_card called with:', displayValue);
-    
     const selectors = [
         '[data-stat="ets-price"]',
         '.stat-value[data-stat="ets-price"]'
     ];
     
-    let updatedCount = 0;
     selectors.forEach(selector => {
         const elements = $(selector);
-        console.log(`Selector "${selector}" found ${elements.length} elements:`, elements);
-        
-        elements.each(function(index) {
-            const element = $(this);
-            const oldValue = element.text();
-            element.text(displayValue);
-            console.log(`Updated element ${index}: "${oldValue}" → "${displayValue}"`);
-            updatedCount++;
-        });
+        if (elements.length > 0) {
+            elements.each(function() {
+                $(this).text(displayValue);
+            });
+        }
     });
-    
-    console.log(`Total elements updated: ${updatedCount}`);
-    
-    // Verify the update worked
-    setTimeout(() => {
-        const allElements = $('[data-stat="ets-price"]');
-        console.log('Verification - all ets-price elements after update:');
-        allElements.each(function(index) {
-            console.log(`Element ${index}: "${$(this).text()}"`);
-        });
-    }, 100);
 };
 
 /**
@@ -222,35 +186,25 @@ cbam.update_ets_price_stat_card = function(displayValue) {
  */
 cbam.refresh_ets_price_options = function(filters, ets_price_type, year) {
     if (!ets_price_type || !year) {
-        console.log('Missing required parameters for ETS price refresh');
         return;
     }
-    
-    console.log('Refreshing ETS Price options for:', { ets_price_type, year });
     
     // Fetch latest price for the selected year and type
     frappe.call({
         method: 'cbam.cbam.page.various_cost_comparisons.various_cost_comparisons.get_latest_ets_price',
         args: { year: year, ets_price_type: ets_price_type },
         callback: function(r) {
-            console.log('Backend response:', r);
-            
             if (r.message) {
                 const priceData = r.message;
-                const displayValue = `${priceData.price} (${priceData.price_year})`;
-                
-                console.log('Price data received:', priceData);
-                console.log('Display value for stat card:', displayValue);
+                const displayValue = `€${priceData.price}`;
                 
                 // Update the ETS Price stat card
                 cbam.update_ets_price_stat_card(displayValue);
             } else {
-                console.log('No ETS price data found for year:', year, 'type:', ets_price_type);
                 cbam.update_ets_price_stat_card('0.0');
             }
         },
         error: function(err) {
-            console.log('Error fetching ETS price:', err);
             cbam.update_ets_price_stat_card('0.0');
         }
     });

--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.js
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.js
@@ -64,8 +64,17 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                         standard_emission_cost = 0;
                     }
                 }
+                
+                // Convert units for display
+                const cbam_benchmark = Number(row.cbam_benchmark) || 0;
+                const standard_emission_factor = Number(row.standard_emission_factor) || 0;
+                const real_emission_value = Number(row.real_emission_value) || 0;
+                
                 return {
                     ...row,
+                    cbam_benchmark: cbam_benchmark.toFixed(3),
+                    standard_emission_factor: standard_emission_factor.toFixed(3),
+                    real_emission_value: real_emission_value.toFixed(3),
                     real_emission_cost: real_emission_cost.toFixed(3),
                     standard_emission_cost: standard_emission_cost.toFixed(3)
                 };
@@ -145,57 +154,50 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
             // Wait for page to fully load
             setTimeout(() => {
                 // Find the year and ETS price type fields
-                const yearField = $('label:contains("Year")').closest('.form-group').find('input, select');
-                const etsPriceTypeField = $('label:contains("ETS Price Basis")').closest('.form-group').find('input, select');
+                const yearField = $('label:contains("Year")').closest('.form-group').find('select');
+                const etsPriceTypeField = $('label:contains("ETS Price Basis")').closest('.form-group').find('select');
                 
                 if (yearField.length > 0 && etsPriceTypeField.length > 0) {
-                    // Populate Future options with proper format
-                    const currentYear = new Date().getFullYear();
-                    const futureOptions = ['', 'Actual'];
-                    
-                    // Add Future option with generic format
-                    futureOptions.push('Future');
+                    // Populate ETS Price Type options
+                    const etsOptions = ['', 'Spot Price', 'Future (Dec)'];
                     
                     // Update the ETS Price Type field options
                     etsPriceTypeField.empty();
-                    futureOptions.forEach(option => {
+                    etsOptions.forEach(option => {
                         if (option === '') {
                             etsPriceTypeField.append('<option value=""></option>');
-                        } else if (option === 'Actual') {
-                            etsPriceTypeField.append('<option value="Actual">Spot Price</option>');
-                        } else if (option === 'Future') {
-                            etsPriceTypeField.append('<option value="Future">Future (Dec)</option>');
+                        } else {
+                            etsPriceTypeField.append(`<option value="${option}">${option}</option>`);
                         }
                     });
                     
-                    // Set default value to Actual (Spot Price)
-                    etsPriceTypeField.val('Actual');
+                    // Set default value to Spot Price
+                    etsPriceTypeField.val('Spot Price');
                     
                     // Add change event listener to year field
                     yearField.on('change', function() {
                         const selectedYear = parseInt($(this).val());
                         const currentYear = new Date().getFullYear();
                         
-                        console.log('Year changed to:', selectedYear, 'Current year:', currentYear);
+            
                         
                         if (selectedYear && selectedYear > currentYear) {
-                            // Future year: set ETS Price Type to Future and make read-only
-                            etsPriceTypeField.val('Future');
+                            // Future year: set ETS Price Type to Future (Dec) and make read-only
+                            etsPriceTypeField.val('Future (Dec)');
                             etsPriceTypeField.prop('disabled', true);
                         } else if (selectedYear && selectedYear == currentYear) {
-                            // Current year: make ETS Price Type editable and set to Actual (Spot Price)
+                            // Current year: make ETS Price Type editable and set to Spot Price
                             etsPriceTypeField.prop('disabled', false);
-                            etsPriceTypeField.val('Actual');
+                            etsPriceTypeField.val('Spot Price');
                         } else {
-                            // Past year: make ETS Price Type editable and set to Actual (Spot Price)
+                            // Past year: make ETS Price Type editable and set to Spot Price
                             etsPriceTypeField.prop('disabled', false);
-                            etsPriceTypeField.val('Actual');
+                            etsPriceTypeField.val('Spot Price');
                         }
                         
                         // Trigger filter change to update ETS Price
                         if (selectedYear) {
                             const selectedEtsType = etsPriceTypeField.val();
-                            console.log('Triggering ETS price update for year:', selectedYear, 'type:', selectedEtsType);
                             if (selectedEtsType) {
                                 // Manually trigger the filter change to update ETS Price
                                 cbam.refresh_ets_price_options(filters, selectedEtsType, selectedYear);
@@ -206,7 +208,6 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                     // Add change event listener to ETS Price Type field
                     etsPriceTypeField.on('change', function() {
                         const selectedEtsType = $(this).val();
-                        console.log('ETS Price Basis changed to:', selectedEtsType);
                         
                         // Ensure Year field is never read-only
                         yearField.prop('disabled', false);
@@ -214,7 +215,6 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                         
                         // Update ETS Price when ETS Price Type changes
                         const selectedYear = parseInt(yearField.val());
-                        console.log('Triggering ETS price update for year:', selectedYear, 'type:', selectedEtsType);
                         if (selectedYear && selectedEtsType) {
                             // Manually trigger the filter change to update ETS Price
                             cbam.refresh_ets_price_options(filters, selectedEtsType, selectedYear);
@@ -238,23 +238,23 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                     <div class="row mb-4 align-items-center">
                         <div class="col">
                             <div class="section-title mb-2">📅 Calculation Based On</div>
-                            <div class="row gx-2" id="filter-section-group-2"></div>
+                            <div class="row gx-0 align-items-center">
+                                <div class="col-6" id="filter-section-group-2"></div>
+                                <div class="col-4" id="compact-stat-row"></div>
+                            </div>
                         </div>
                         <div class="col-auto d-flex align-items-center" style="margin-top: 22px;">
                             <button class="btn btn-primary btn-xs clear-selections text-nowrap filter-clear-btn" id="clear-group-2">Clear All</button>
                         </div>
                     </div>
-                    <div class="row mb-4" id="card-section">
-                        <div class="row gx-3" id="compact-stat-row"></div>
-                    </div>
                     <div class="frappe-card mb-4" id="chart-section"></div>
                     <!-- Select Article filter section -->
                     <div class="row mb-3 align-items-center">
-                        <div class="col">
+                        <div class="col-10">
                             <div class="section-title mb-2">🧾 Select Article</div>
-                            <div class="row gx-2" id="filter-section-group-1"></div>
+                            <div class="row gx-1" id="filter-section-group-1"></div>
                         </div>
-                        <div class="col-auto d-flex align-items-center" style="margin-top: 22px;">
+                        <div class="col-2 d-flex align-items-center justify-content-end" style="margin-top: 22px;">
                             <button class="btn btn-primary btn-xs clear-selections text-nowrap filter-clear-btn" id="clear-group-1">Clear All</button>
                         </div>
                     </div>
@@ -292,13 +292,14 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                 supplier: cbam.create_filter('Supplier', 'MultiSelectList', 'supplier', '#filter-section-group-1', []),
                 article_number: cbam.create_filter('Article Number', 'MultiSelectList', 'article_number', '#filter-section-group-1', []),
                 reporting_period: cbam.create_filter('Reporting Period', 'MultiSelectList', 'reporting_period', '#filter-section-group-1', []),
-                year: cbam.create_filter('Year', 'Link', 'year', '#filter-section-group-2', null, 'Year', currentYear),
-                ets_price_type: cbam.create_filter('ETS Price Basis', 'Select', 'ets_price_type', '#filter-section-group-2', ['', 'Actual', 'Future'], null, 'Actual'),
+                year: cbam.create_filter('Year', 'Select', 'year', '#filter-section-group-2', [], null, currentYear),
+                ets_price_type: cbam.create_filter('ETS Price Basis', 'Select', 'ets_price_type', '#filter-section-group-2', ['', 'Spot Price', 'Future (Dec)'], null, 'Spot Price'),
             };
 
-            console.log('Filters created:', filters);
-            console.log('ETS Price Type filter:', filters.ets_price_type);
-            console.log('Year filter:', filters.year);
+
+
+            // Populate year filter with available years from ETS Carbon Price
+            populate_year_filter(filters.year);
 
             // CN Code: no dependencies
             filters.cn_code.df.get_data = function(txt) {
@@ -343,15 +344,59 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
         }
 
         /**
+         * Populate the year filter with available years from ETS Carbon Price table
+         * @param {Object} yearFilter - The year filter control
+         */
+        function populate_year_filter(yearFilter) {
+            frappe.call({
+                method: 'cbam.cbam.page.various_cost_comparisons.various_cost_comparisons.get_available_years',
+                callback: function(r) {
+                    if (r.message && r.message.length > 0) {
+                        // Set the options for the Select field
+                        yearFilter.df.options = r.message;
+                        
+                        // Refresh the filter
+                        yearFilter.refresh();
+                        
+                        // Set default value to current year if available, otherwise first available year
+                        const currentYear = frappe.datetime.get_today().split('-')[0];
+                        const availableYears = r.message;
+                        
+                        if (availableYears.includes(currentYear)) {
+                            yearFilter.set_value(currentYear);
+                        } else if (availableYears.length > 0) {
+                            yearFilter.set_value(availableYears[0]);
+                        }
+                    } else {
+                        // Fallback to current year
+                        const currentYear = frappe.datetime.get_today().split('-')[0];
+                        yearFilter.df.options = [currentYear];
+                        yearFilter.refresh();
+                        yearFilter.set_value(currentYear);
+                    }
+                },
+                error: function(err) {
+                    console.error('Error fetching available years:', err);
+                    // Fallback to current year
+                    const currentYear = frappe.datetime.get_today().split('-')[0];
+                    yearFilter.df.options = [currentYear];
+                    yearFilter.refresh();
+                    yearFilter.set_value(currentYear);
+                }
+            });
+        }
+
+        /**
          * Update stat card values based on filter changes.
          * @param {string} key
          * @param {Object} filters
          */
         function update_stat_card_values(key, filters) {
             if (key === 'ets_price') {
-                $('.stat-value[data-stat="ets-price"]').text(filters.ets_price || 0.0);
+                const etsPriceValue = filters.ets_price || 0.0;
+                const displayValue = etsPriceValue !== 0.0 ? `€${etsPriceValue}` : '0.0';
+                $('.stat-value[data-stat="ets-price"]').text(displayValue);
                 // After updating ETS Price, reload table and chart with new value
-                console.log('ETS Price updated, reloading table and chart...');
                 load_report_table(true, filters);
                 return;
             }
@@ -364,11 +409,8 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                     if (!r.message) return;
                     
                     const updated_values = {
-                        'standard-emission-value': r.message.emission_value || 0.0,
-                        'bench-mark-emission-value': r.message.bench_mark || 0.0,
                         'cbam-factor': r.message.cbam_factor || 0.0,
                         'ets-price': r.message.ets_price || 0.0,
-                        'year': filters.year || frappe.datetime.get_today().split('-')[0],
                     };
                     
                     Object.entries(updated_values).forEach(([key, val]) => {
@@ -384,11 +426,15 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                             }
                         }
                         
+                        // Special formatting for ETS Price - add Euro symbol
+                        if (key === 'ets-price' && val !== 0.0 && val !== null && val !== undefined) {
+                            displayValue = `€${val}`;
+                        }
+                        
                         $(`.stat-value[data-stat="${key}"]`).text(displayValue);
                     });
                     
                     // After updating stat cards, reload table and chart with new values
-                    console.log('Stat cards updated, reloading table and chart...');
                     load_report_table(true, filters);
                 },
                 error: function () {
@@ -396,30 +442,24 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                 }
             });
         }
-
         /** 
          * Clear and render stat cards with default values.
          */
         function clear_stats() {
             // Check if stat cards already exist to prevent duplication
             if ($('#compact-stat-row .stat-card').length > 0) {
-                console.log('Stat cards already exist, skipping creation');
                 return;
             }
             
             const compact_stats = [
-                { label: 'Standard Emission Value', value: '--', display_label: 'Standard Emissions Factor [t CO2/t Product]' },
-                { label: 'Bench Mark Emission Value', value: '--', display_label: 'Benchmark [t CO2/t Product]' },
                 { label: 'CBAM Factor', value: '--' },
-                { label: 'ETS Price', value: '--', display_label: 'EUA Price [€/t CO2]' },
-                { label: 'Year', value: 2025 },
+                { label: 'ETS Price', value: '€--', display_label: 'EUA Price [€/t CO2]' },
             ];
             $('#compact-stat-row').empty();
             compact_stats.forEach(stat => {
                 const displayLabel = stat.display_label || stat.label;
-                $('#compact-stat-row').append(`<div class='col mb-2'>${render_compact_card_with_data_stat(displayLabel, stat.value, stat.label)}</div>`);
+                $('#compact-stat-row').append(`<div class='me-2'>${render_compact_card_with_data_stat(displayLabel, stat.value, stat.label)}</div>`);
             });
-            console.log('Stat cards created:', $('#compact-stat-row .stat-card').length);
         }
 
         /**
@@ -575,9 +615,9 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
          */
         function render_compact_card_with_data_stat(displayLabel, value, dataStatLabel) {
             return `
-                <div class="frappe-card d-flex flex-column justify-content-center align-items-center border rounded shadow-sm p-3 text-center stat-card h-100">
-                    <div class="text-muted small">${displayLabel}</div>
-                    <div class="fw-bold fs-5 mt-1 stat-value" data-stat="${dataStatLabel.toLowerCase().replace(/ /g, '-')}">${value}</div>
+                <div class="frappe-card d-flex flex-row justify-content-between align-items-center border rounded p-2 text-start stat-card h-100">
+                    <div class="text-muted small mb-0">${displayLabel}</div>
+                    <div class="fw-bold fs-6 ms-2 stat-value" data-stat="${dataStatLabel.toLowerCase().replace(/ /g, '-')}">${value}</div>
                 </div>
             `;
         }
@@ -608,6 +648,129 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
           #dashboard-tabs .nav-link {
             color: #000;
             font-weight: 500;
+          }
+          
+          /* Compact stat card styles - matching filter height and inline with filters */
+          .stat-card {
+            min-width: 120px;
+            width: 140px;
+            max-width: 140px;
+            height: 38px !important;
+            transition: all 0.2s ease;
+            border: 1px solid #d1d5db;
+            background: #fff;
+            display: inline-block;
+            vertical-align: top;
+          }
+          
+          .stat-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15) !important;
+            border-color: #3b82f6;
+          }
+          
+          .stat-card {
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            border-radius: 8px;
+            border: 1px solid #e5e7eb;
+          }
+          
+          .stat-card .text-muted {
+            font-size: 0.75rem;
+            line-height: 1.3;
+            color: #6b7280;
+            margin-bottom: 2px;
+            font-weight: 600;
+          }
+          
+          .stat-card .stat-value {
+            font-size: 1rem !important;
+            line-height: 1.3;
+            white-space: nowrap;
+            color: #2a2abd;
+            font-weight: 600;
+          }
+          
+          /* Ensure filters and stat cards are properly aligned */
+          #filter-section-group-2 {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            justify-content: flex-start;
+            width: 100%;
+          }
+          
+          #compact-stat-row {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            justify-content: flex-end;
+            width: 100%;
+          }
+          
+          /* Ensure filters have consistent width using filter.js column classes */
+          #filter-section-group-2 .form-control,
+          #filter-section-group-2 .frappe-control {
+            min-width: 140px;
+            width: 100%;
+            max-width: 160px;
+          }
+          
+          /* Year filter should be slightly wider */
+          #filter-section-group-2 .form-control[data-fieldname="year"] {
+            min-width: 140px;
+            width: 100%;
+            max-width: 150px;
+          }
+          
+          /* ETS Price Type filter should be wider for the text */
+          #filter-section-group-2 .form-control[data-fieldname="ets_price_type"] {
+            min-width: 160px;
+            width: 100%;
+            max-width: 170px;
+          }
+          
+          /* Responsive adjustments */
+          @media (max-width: 768px) {
+            .stat-card {
+              min-width: 160px;
+              max-width: 200px;
+              height: 45px !important;
+            }
+            
+            .stat-card .text-muted {
+              font-size: 0.65rem;
+            }
+            
+            .stat-card .stat-value {
+              font-size: 0.8rem !important;
+            }
+            
+            #filter-section-group-2,
+            #compact-stat-row {
+              flex-wrap: wrap;
+              gap: 0.15rem;
+            }
+            
+            /* Maintain filter widths on mobile */
+            #filter-section-group-2 .form-control,
+            #filter-section-group-2 .frappe-control {
+              min-width: 140px;
+              width: 100%;
+              max-width: none;
+            }
+            
+            #filter-section-group-2 .form-control[data-fieldname="year"] {
+              min-width: 140px;
+              width: 100%;
+              max-width: none;
+            }
+            
+            #filter-section-group-2 .form-control[data-fieldname="ets_price_type"] {
+              min-width: 140px;
+              width: 100%;
+              max-width: none;
+            }
           }
         </style>`).appendTo('head');
     })();

--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
@@ -1,7 +1,7 @@
 import frappe
 import json
 from datetime import datetime
-import re
+
 
 @frappe.whitelist()
 def get_report_data(filters=None, selected_filters=None, start=0, page_length=50):
@@ -33,15 +33,15 @@ def get_columns():
         {"fieldname": "article_number", "fieldtype": "Data", "label": "Article Number", "width": 200},
         {"fieldname": "supplier", "fieldtype": "Data", "label": "Supplier", "width": 200},
         {"fieldname": "raw_mass_tonne", "fieldtype": "Data", "label": "Mass [t]", "width": 150},
-        # {"fieldname": "carbon_price_due", "fieldtype": "Data", "label": "Carbon Price Due", "width": 150},
         {"fieldname": "installation_country", "fieldtype": "Data", "label": "Installation Country", "width": 180},
-        {"fieldname": "standard_emission_cost", "fieldtype": "Data", "label": "Standard Cost", "width": 180},
-        {"fieldname": "real_emission_value", "fieldtype": "Data", "label": "Specific (Direct) Emission Value [kgCO2e/kg]", "width": 325},
+        {"fieldname": "cbam_benchmark", "fieldtype": "Data", "label": "CBAM Benchmark [tCO2/t product]", "width": 200},
+        {"fieldname": "standard_emission_factor", "fieldtype": "Data", "label": "Standard Emission Factor [tCO2/t product]", "width": 220},
+        {"fieldname": "standard_emission_cost", "fieldtype": "Data", "label": "Standard Cost [€]", "width": 180},
+        {"fieldname": "real_emission_value", "fieldtype": "Data", "label": "Specific (Direct) Emission Value [tCO2/t product]", "width": 280},
         {"fieldname": "real_emission_cost", "fieldtype": "Data", "label": "Cost Based on Specific Emissions [€]", "width": 280},
     ]
 
 def get_data(filters=None, selected_filters=None, start=0, page_length=50):
-    print("filters", selected_filters)
     filters = filters or {}
     selected_filters = selected_filters or {}
     try:
@@ -70,25 +70,83 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
 
     #set where conditions
     where_sql, where_sql_eg = set_conditions(declarants, filters, where_clauses, where_clauses_eg)
-
-    cbam_factor = float(selected_filters.get('cbam_factor', 0.0) or 0.0)
-    bench_mark = float(selected_filters.get('bench_mark', 0.0) or 0.0)
-    emission_value = float(selected_filters.get('emission_value', 0.0) or 0.0)
+    # Initialize ETS price
+    ets_carbon_price = 0.0
     
-    # Handle ETS price value safely - extract numeric part if it contains display text
-    ets_price_raw = selected_filters.get('ets_price_value', 0.0) or selected_filters.get('ets_price', 0.0) or 0.0
-    if isinstance(ets_price_raw, str) and '(' in ets_price_raw:
-        # Extract numeric part from display value like "22 (2025)"
-        numeric_match = re.match(r'^([\d.]+)', ets_price_raw)
-        if numeric_match:
-            ets_price_raw = float(numeric_match.group(1))
-        else:
-            ets_price_raw = 0.0
+    # Initialize values with default values
+    bench_mark = 0.0
+    emission_value = 0.0
+    cbam_factor = 0.0
     
-    ets_carbon_price = float(ets_price_raw) if ets_price_raw else 0.0
-
+    # Fetch bench_mark, emission_value, and cbam_factor from backend based on year
+    year = selected_filters.get('year', None)
+    ets_price_type = selected_filters.get('ets_price_type', None)
+    
+    if year and ets_price_type:
+        # Get the values from the same tables used in get_cards_value
+        sql_params = {
+            'year': year,
+            'ets_price_type': ets_price_type
+        }
+        
+        sql = """
+            SELECT 
+                cf.cbam_factor,
+                cnb.bench_mark,
+                sev.emission_value,
+                ecp.price AS ets_price
+            FROM `tabCBAM Factor` cf
+            LEFT JOIN `tabCBAM Benchmark` cnb 
+                ON cnb.year = %(year)s
+            LEFT JOIN `tabStandard Emission Value` sev 
+                ON sev.year = %(year)s
+            LEFT JOIN (
+                -- Get the latest price_date within the selected year for the specific ETS price type
+                SELECT 
+                    price_year,
+                    ets_price_type,
+                    price,
+                    price_date
+                FROM `tabETS Carbon Price` ecp_inner
+                WHERE ecp_inner.price_year = %(year)s
+                AND ecp_inner.ets_price_type = %(ets_price_type)s
+                ORDER BY
+                    CASE
+                        WHEN %(ets_price_type)s = 'Spot Price' THEN ecp_inner.price_date
+                        ELSE ecp_inner.modified
+                    END DESC
+                LIMIT 1
+            ) ecp ON ecp.price_year = %(year)s AND ecp.ets_price_type = %(ets_price_type)s
+            WHERE cf.year = %(year)s
+            LIMIT 1
+        """
+        
+        result = frappe.db.sql(sql, sql_params, as_dict=True)
+        if result:
+            cbam_factor = float(result[0].get('cbam_factor', 0.0) or 0.0)
+            bench_mark = float(result[0].get('bench_mark', 0.0) or 0.0)
+            emission_value = float(result[0].get('emission_value', 0.0) or 0.0)
+            ets_carbon_price = float(result[0].get('ets_price', 0.0) or 0.0)
+    
     # Count total rows for pagination
     total_count = get_count(where_sql, where_sql_eg)
+
+    # Helper function to build cost calculation expressions
+    def build_cost_calculations(table_alias):
+        return f"""
+            {bench_mark} AS cbam_benchmark,
+            {emission_value} AS standard_emission_factor,
+            ((
+                {emission_value}
+                - ({bench_mark} * {cbam_factor})
+                - (({emission_value} * IFNULL({table_alias}.carbon_price_due, 0.0)) / {ets_carbon_price})
+            ) * IFNULL({table_alias}.raw_mass_tonne, 0.0) * {ets_carbon_price}) AS standard_emission_cost,
+            IFNULL({table_alias}.specific_direct_embedded_emissions,0.0) AS real_emission_value,
+            ((
+                IFNULL({table_alias}.specific_direct_embedded_emissions,0.0) - ({cbam_factor} * {bench_mark})
+                - ((IFNULL({table_alias}.specific_direct_embedded_emissions,0.0) * IFNULL({table_alias}.carbon_price_due, 0.0)) / {ets_carbon_price})
+            ) * IFNULL({table_alias}.raw_mass_tonne, 0.0) * {ets_carbon_price}) AS real_emission_cost
+        """
 
     # Main data query with LIMIT/OFFSET for pagination
     data_query = f"""
@@ -98,19 +156,9 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                 eg.article_no AS article_number,
                 eg.supplier,
                 IFNULL(eg.raw_mass_tonne,0.0) AS raw_mass_tonne,
-                IFNULL(eg.carbon_price_due,0.0) as carbon_price_due,
                 eg.installation_country,
-                IFNULL(eg.specific_direct_embedded_emissions,0.0) AS real_emission_value,             
-                ((
-                    IFNULL(eg.specific_direct_embedded_emissions,0.0) - ({cbam_factor} * {bench_mark})
-                    - ((IFNULL(eg.specific_direct_embedded_emissions,0.0) * IFNULL(eg.carbon_price_due, 0.0)) / {ets_carbon_price})
-                ) * IFNULL(eg.raw_mass_tonne, 0.0) * {ets_carbon_price}) AS real_emission_cost,
-
-                ((
-                    {emission_value}
-                    - ({bench_mark} * {cbam_factor})
-                    - (({emission_value} * IFNULL(eg.carbon_price_due, 0.0)) / {ets_carbon_price})
-                ) * IFNULL(eg.raw_mass_tonne, 0.0) * {ets_carbon_price}) AS standard_emission_cost
+                {build_cost_calculations('eg')},
+                eg.name
             FROM `tabExternal Good` eg
             {where_sql_eg}
             UNION
@@ -119,19 +167,9 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                 g.article_number,
                 g.supplier_name AS supplier,
                 IFNULL(g.raw_mass_tonne,0.0) AS raw_mass_tonne,
-                IFNULL(g.carbon_price_due,0.0) AS carbon_price_due,
                 g.installation_country,    
-                IFNULL(g.specific_direct_embedded_emissions,0.0) AS real_emission_value,
-                ((
-                    IFNULL(g.specific_direct_embedded_emissions,0.0) - ({cbam_factor} * {bench_mark})
-                    - ((IFNULL(g.specific_direct_embedded_emissions,0.0) * IFNULL(g.carbon_price_due,0.0)) / {ets_carbon_price})
-                ) * IFNULL(g.raw_mass_tonne,0.0) * {ets_carbon_price}) AS real_emission_cost,
-                ((
-                    {emission_value}
-                    - ({bench_mark} * {cbam_factor})
-                    - (({emission_value} * IFNULL(g.carbon_price_due, 0.0)) / {ets_carbon_price})
-                )
-                * IFNULL(g.raw_mass_tonne, 0.0) * {ets_carbon_price}) AS standard_emission_cost
+                {build_cost_calculations('g')},
+                g.name
             FROM `tabGood` g
             {where_sql}
         ) AS main_table
@@ -170,13 +208,8 @@ def set_conditions(declarants, filters, where_clauses, where_clauses_eg):
     # Only fetch Good records with status = 'Data Submitted'
     where_clauses.append("g.status = 'Data Submitted'")
 
-    where_sql = ""
-    if where_clauses:
-        where_sql = "WHERE " + " AND ".join(where_clauses)
-        
-    where_sql_eg = ""
-    if where_clauses_eg:
-        where_sql_eg = "WHERE " + " AND ".join(where_clauses_eg) if where_clauses_eg else ""
+    where_sql = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
+    where_sql_eg = "WHERE " + " AND ".join(where_clauses_eg) if where_clauses_eg else ""
 
     return where_sql, where_sql_eg
 
@@ -184,32 +217,29 @@ def get_count(where_sql, where_sql_eg):
     count_query = f"""
         SELECT COUNT(*) FROM (
             SELECT 
-                eg.cn_code, eg.article_no as article_number, eg.supplier, eg.raw_mass_tonne, eg.installation_country,
+                eg.name, eg.cn_code, eg.article_no as article_number, eg.supplier, eg.raw_mass_tonne, eg.installation_country,
                 eg.specific_direct_embedded_emissions, eg.carbon_price_due
             FROM `tabExternal Good` eg
             {where_sql_eg}
-            
             UNION
             SELECT 
-                g.cn_code, g.article_number, g.supplier_name as supplier, g.raw_mass_tonne, g.installation_country,
+                g.name, g.cn_code, g.article_number, g.supplier_name as supplier, g.raw_mass_tonne, g.installation_country,
                 g.specific_direct_embedded_emissions, g.carbon_price_due
             FROM `tabGood` g
             {where_sql}
         ) AS count_table
 
     """
-    result = list(frappe.db.sql(count_query))
-    total_count = result[0][0] if result else 0
-    return total_count
+    result = frappe.db.sql(count_query)
+    return result[0][0] if result else 0
 
 def get_chart_data(data):
     """Process data to create chart data grouped by article and supplier for bar chart"""
+    if not data:
+        return {'labels': [], 'articles': [], 'suppliers': [], 'actual_costs': [], 'standard_costs': []}
+    
     # If data contains article_number and supplier, use those for x-axis
-    articles = []
-    suppliers = []
-    actual_costs = []
-    standard_costs = []
-    labels = []
+    articles, suppliers, actual_costs, standard_costs, labels = [], [], [], [], []
 
     for row in data:
         article = row.get('article_number', '')
@@ -218,16 +248,8 @@ def get_chart_data(data):
         suppliers.append(supplier)
         labels.append(f"{article} ({supplier})")
         # Ensure costs are numbers, not objects
-        actual_cost = row.get('real_emission_cost', 0.0)
-        standard_cost = row.get('standard_emission_cost', 0.0)
-        try:
-            actual_cost = float(actual_cost)
-        except Exception:
-            actual_cost = 0.0
-        try:
-            standard_cost = float(standard_cost)
-        except Exception:
-            standard_cost = 0.0
+        actual_cost = float(row.get('real_emission_cost', 0.0) or 0.0)
+        standard_cost = float(row.get('standard_emission_cost', 0.0) or 0.0)
         actual_costs.append(actual_cost)
         standard_costs.append(standard_cost)
 
@@ -256,23 +278,14 @@ def get_cards_value(filters=None):
 
     filters = json.loads(filters) if filters else {}
     
-    # Map frontend display names to backend values
-    ets_price_type_mapping = {
-        'Spot Price': 'Actual',
-        'Future': 'Future'
-    }
-    
     # Provide default values for missing keys
     year = filters.get('year', datetime.now().year) # Fixed datetime access
     ets_price_type = filters.get('ets_price_type', 'Spot Price')  # Default to Spot Price if not provided
     
-    # Convert frontend display name to backend value
-    backend_ets_price_type = ets_price_type_mapping.get(ets_price_type, 'Actual')
-    
     # Create a safe parameters dict for SQL
     sql_params = {
         'year': year,
-        'ets_price_type': backend_ets_price_type
+        'ets_price_type': ets_price_type
     }
 
     sql = """
@@ -286,10 +299,24 @@ def get_cards_value(filters=None):
             ON cnb.year = %(year)s
         LEFT JOIN `tabStandard Emission Value` sev 
             ON sev.year = %(year)s
-        LEFT JOIN `tabETS Carbon Price` ecp 
-            ON ecp.price_year = %(year)s AND ecp.ets_price_type = %(ets_price_type)s
+        LEFT JOIN (
+            -- Get the latest price_date within the selected year for the specific ETS price type
+            SELECT 
+                price_year,
+                ets_price_type,
+                price,
+                price_date
+            FROM `tabETS Carbon Price` ecp_inner
+            WHERE ecp_inner.price_year = %(year)s 
+            AND ecp_inner.ets_price_type = %(ets_price_type)s
+            ORDER BY 
+                CASE 
+                    WHEN %(ets_price_type)s = 'Spot Price' THEN ecp_inner.price_date
+                    ELSE ecp_inner.modified
+                END DESC
+            LIMIT 1
+        ) ecp ON ecp.price_year = %(year)s AND ecp.ets_price_type = %(ets_price_type)s
         WHERE cf.year = %(year)s
-
         LIMIT 1
     """
 
@@ -297,58 +324,50 @@ def get_cards_value(filters=None):
     return result[0] if result else {}
 
 
-def fetch_external_good_options(filter_type, txt, declarants, cn_code_list, supplier_list):
+def _build_filter_options(filter_type, txt, declarants, cn_code_list, supplier_list, table_name, field_mappings):
+    """Helper function to build filter options for both Good and External Good tables"""
     filters = []
     if declarants:
         filters.append(["declarant", "in", declarants])
     if cn_code_list:
         filters.append(["cn_code", "in", cn_code_list])
+    
+    supplier_field = field_mappings["supplier"]
     if supplier_list and filter_type != "supplier":
-        filters.append(["supplier", "in", supplier_list])
+        filters.append([supplier_field, "in", supplier_list])
+    
     if txt:
         if filter_type == "supplier":
-            filters.append(["supplier", "like", f"%{txt}%"])
+            filters.append([supplier_field, "like", f"%{txt}%"])
         elif filter_type == "article_number":
-            filters.append(["article_no", "like", f"%{txt}%"])
+            filters.append([field_mappings["article_number"], "like", f"%{txt}%"])
         elif filter_type == "reporting_period":
-            filters.append(["reporting_period", "like", f"%{txt}%"])
-    field_map = {
+            filters.append([field_mappings["reporting_period"], "like", f"%{txt}%"])
+    
+    field = field_mappings.get(filter_type)
+    if not field:
+        return []
+    
+    results = frappe.db.get_list(table_name, fields=[field], filters=filters, distinct=True, limit=20)
+    return [row.get(field) for row in results if row.get(field)]
+
+
+def fetch_external_good_options(filter_type, txt, declarants, cn_code_list, supplier_list):
+    field_mappings = {
         "supplier": "supplier",
         "article_number": "article_no",
         "reporting_period": "reporting_period"
     }
-    field = field_map.get(filter_type)
-    if not field:
-        return []
-    results = frappe.db.get_list("External Good", fields=[field], filters=filters, distinct=True, limit=20)
-    return [row.get(field) for row in results if row.get(field)]
+    return _build_filter_options(filter_type, txt, declarants, cn_code_list, supplier_list, "External Good", field_mappings)
 
 
 def fetch_good_options(filter_type, txt, declarants, cn_code_list, supplier_list):
-    filters = []
-    if declarants:
-        filters.append(["declarant", "in", declarants])
-    if cn_code_list:
-        filters.append(["cn_code", "in", cn_code_list])
-    if supplier_list and filter_type != "supplier":
-        filters.append(["supplier_name", "in", supplier_list])
-    if txt:
-        if filter_type == "supplier":
-            filters.append(["supplier_name", "like", f"%{txt}%"])
-        elif filter_type == "article_number":
-            filters.append(["article_number", "like", f"%{txt}%"])
-        elif filter_type == "reporting_period":
-            filters.append(["internal_customs_import_number", "like", f"%{txt}%"])
-    field_map = {
+    field_mappings = {
         "supplier": "supplier_name",
         "article_number": "article_number",
         "reporting_period": "internal_customs_import_number"
     }
-    field = field_map.get(filter_type)
-    if not field:
-        return []
-    results = frappe.db.get_list("Good", fields=[field], filters=filters, distinct=True, limit=20)
-    return [row.get(field) for row in results if row.get(field)]
+    return _build_filter_options(filter_type, txt, declarants, cn_code_list, supplier_list, "Good", field_mappings)
 
 
 def merge_and_format_options(*option_lists):
@@ -374,30 +393,44 @@ def get_filter_options(txt=None, filter_type=None, cn_code=None, supplier=None):
 
 
 @frappe.whitelist()
+def get_available_years():
+    """Get years from ETS Carbon Price table that have prices"""
+    # Get distinct years from ETS Carbon Price table that have prices
+    sql = """
+        SELECT DISTINCT price_year 
+        FROM `tabETS Carbon Price` 
+        WHERE price_year IS NOT NULL 
+        AND price IS NOT NULL 
+        AND price > 0
+        ORDER BY price_year ASC
+    """
+    
+    result = frappe.db.sql(sql, as_dict=True)
+    
+    # Extract years and format them for Link field
+    years = [str(row.price_year) for row in result if row.price_year]
+    
+    return years
+
+@frappe.whitelist()
 def get_latest_ets_price(year=None, ets_price_type=None):
     """Get the latest available ETS price for given year and type"""
-    print(f"get_latest_ets_price called with year={year}, ets_price_type={ets_price_type}")
-    
     if not year or not ets_price_type:
-        print("Missing year or ets_price_type")
         return None
     
     # Convert year to integer if it's a string
     try:
         year = int(year)
     except (ValueError, TypeError):
-        print(f"Invalid year format: {year}")
         return None
     
     # Use different ordering logic based on ETS price type
-    if ets_price_type == 'Actual':
-        # For Actual prices: order by price_date, then by modified to handle same-date ties
+    if ets_price_type == 'Spot Price':
+        # For Spot Price: order by price_date DESC to get the most recent price within the selected year
         order_clause = "ORDER BY price_date DESC, modified DESC"
-        print(f"Using Actual ordering: {order_clause}")
     else:
-        # For Future prices: order by creation date to get most recently announced/created price
+        # For Future (Dec) prices: order by creation date to get most recently announced/created price within the selected year
         order_clause = "ORDER BY modified DESC"
-        print(f"Using Future ordering: {order_clause}")
     
     sql = f"""
         SELECT 
@@ -413,15 +446,6 @@ def get_latest_ets_price(year=None, ets_price_type=None):
     """
     
     sql_params = {"year": year, "ets_price_type": ets_price_type}
-    print(f"SQL query: {sql}")
-    print(f"SQL params: {sql_params}")
-    
     result = frappe.db.sql(sql, sql_params, as_dict=True)
-    print(f"SQL result: {result}")
     
-    if result:
-        print(f"Returning: {result[0]}")
-        return result[0]
-    else:
-        print("No result found")
-        return None
+    return result[0] if result else None

--- a/cbam/cbam/report/ets_pricing_actual/ets_pricing_actual.py
+++ b/cbam/cbam/report/ets_pricing_actual/ets_pricing_actual.py
@@ -21,7 +21,7 @@ def get_columns():
     ]
 
 def get_data(filters):
-    conditions = {"ets_price_type": "Actual"}
+    conditions = {"ets_price_type": "Spot Price"}
 
     # Apply date filter only if both from and to dates are provided
     if filters.get("from_date") and filters.get("to_date"):

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.js
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.js
@@ -144,8 +144,8 @@ frappe.query_reports["Financial Evaluation"] = {
 			fieldname: "ets_price_type",
 			label: __("ETS Price Type"),
 			fieldtype: "Select",
-			options: ["", "Actual", "Future"],
-			default: "Actual"
+			options: ["", "Spot Price", "Future (Dec)"],
+			default: "Spot Price"
 		},
 		{
 			fieldname: "year",


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/600
Parent Issue: https://git.phamos.eu/gallehr/cbam/-/issues/594


**## Summary**

Updated Various Cost Comparisons page with new ETS price type options, improved layout, and enhanced data fetching logic.


**## Key Changes**

### 🎯 ETS Price Type Updates
- Changed from "Actual/Future" to "Spot Price/Future (Dec)" 
- Eliminated need for frontend-backend value mapping


### �� UI/UX Improvements  
- Reordered table columns: Installation Country, CBAM Benchmark, Standard Emission Factor, Standard Cost, Specific Emission Value, Cost Based on Specific Emissions
- Moved CBAM Benchmark and Standard Emission Factor from stat cards to table columns
- Removed redundant "Year" stat card
- Optimized stat card layout: compact design, Euro symbol (€) for ETS price, increased height for better visibility
- Fixed filter alignment: filters and stat cards now display in one line with proper spacing


### 🔧 Data & Backend Updates
- Year filter now dynamically fetches only years with ETS Carbon Price data
- Enhanced ETS price fetching: uses latest price_date for selected year
- Fixed missing External Good status filter (was only showing 2/8 records)
- Improved calculation value fetching: cbam_factor, benchmark, emission_value, ets_price now fetched directly from database
- Added name field to prevent duplicate rows in table


### �� Code Cleanup
- Removed console.log and print statements
- Eliminated unused imports and redundant variables
- Fixed UnboundLocalError for bench_mark and emission_value variables
- Optimized SQL queries and removed duplicate code

### 📊 Chart Updates
- Changed Y-axis label from "Costs [€]" to "Cost [€]"

<img width="2864" height="1172" alt="image" src="https://github.com/user-attachments/assets/76215d11-7c61-461c-9107-5311ab848a94" />


<img width="1424" height="721" alt="image" src="https://github.com/user-attachments/assets/cbce6e33-0c01-4aa3-843f-ca75998a1d90" />


<img width="2740" height="1414" alt="image" src="https://github.com/user-attachments/assets/87d6916e-af61-4e17-8bb4-a75255aa21b2" />

