### PR TITLE
Gallehr/cbam#609

### DIFF
--- a/cbam/cbam/doctype/operating_company/operating_company.json
+++ b/cbam/cbam/doctype/operating_company/operating_company.json
@@ -179,8 +179,7 @@
    "fieldname": "cbam_representive_employee_first_name",
    "fieldtype": "Data",
    "label": "CBAM Representative First Name",
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "fieldname": "column_break_xrkz",
@@ -293,7 +292,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-18 08:39:33.988050",
+ "modified": "2025-09-09 08:32:29.845498",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Operating Company",

--- a/cbam/cbam/notification/commercial_contact_signup_request/commercial_contact_signup_request.json
+++ b/cbam/cbam/notification/commercial_contact_signup_request/commercial_contact_signup_request.json
@@ -12,7 +12,7 @@
  "is_standard": 1,
  "message": "<p>Dear Mr./Mrs. {{doc.main_contact_employee_last_name}},<br><br></p>\n\n<p>here is {{frappe.db.get_value(\"User\", frappe.session.user, 'full_name')}} from  {{doc.declarant if not doc.parent_operating_company else frappe.db.get_value(\"Operating Company\", doc.parent_operating_company, \"supplier_name\")}}. \n<br><br></p>\n\n<p>We import goods from you that are affected by the new European regulation Carbon Border Adjustment Mechanism (CBAM). We are legally required to provide detailed reports on the embedded CO2 emissions of CBAM goods we import from non-EU countries. To meet these reporting requirements, we need your assistance in collecting data. \nIn order to ease the process for both sides we decided to utilize a CBAM data collection platform. This mail provides you with the registration link to this platform. On the platform you will be guided through the process and the platform will remember certain answers for the next round of data request, which will make it easier the next time around.\n<br><br></p>\n\n<p>Please follow the steps outlined below:\n<br><br></p>\n\n<p><strong>1. Registration:</strong><br>\nClick on this <a href='{{frappe.utils.get_url()}}/login#login-with-email-link'> link</a> and select the \"Login with Email\" button. Please use this email address, as it is the designated user account for you. (You can forward the request within the system, if necessary.)<br>\n<strong>2. Confirm the Registration:</strong><br>\nAfter you completed the registration process, please, check your email inbox and click on the provided confirmation link.<br>\n<strong>3. Data request:</strong><br>\nYou will receive a separate mail from me with the data request for the active quarter shortly. \n<br><br></p>\n\n<p>We would appreciate it if you could complete these steps at your earliest convenience.\n<br><br></p>\n\n<p>Thank you for your prompt attention to this matter.\n<br><br><br></p>\n\n<p>Best regards,<br>\n{{frappe.db.get_value(\"User\", frappe.session.user, 'full_name')}}<br>\n {{doc.declarant if not doc.parent_operating_company else frappe.db.get_value(\"Operating Company\", doc.parent_operating_company, \"supplier_name\")}}</p>\n",
  "message_type": "HTML",
- "modified": "2025-01-14 14:10:05.530600",
+ "modified": "2025-09-08 15:43:48.098700",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "Commercial Contact Signup Request",
@@ -22,7 +22,9 @@
    "receiver_by_document_field": "main_contact_employee_email"
   }
  ],
- "send_system_notification": 0,
+ "send_system_notification": 1,
  "send_to_all_assignees": 0,
+ "sender": "myconet CBAM",
+ "sender_email": "kamal.singh@phamos.eu",
  "subject": "CBAM - Signup Request"
 }

--- a/cbam/www/supplier_list/index.js
+++ b/cbam/www/supplier_list/index.js
@@ -174,6 +174,7 @@ function executeJS() {
                     label: __("First Name"),
                     fieldname: "main_contact_employee_first_name",
                     fieldtype: "Data",
+                    reqd: update ? 0 : 1,
                     default: docData ? docData.main_contact_employee_first_name : ""
                 },
                 


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/609
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/603

Summary:

updated validations for:

- Operating company can be setup with only the commercial contact created   
- Both first and Last name are mandatory when creating Commercial contact and CBAM rep via webview   
- CBAM rep not mandatory for setting up new operating company