### PR TITLE
gallehr/cbam#630: Update Operating Company: Conditional "Update Contact" Button Visibility and Contact Type Selection

### DIFF
--- a/cbam/cbam/doctype/operating_company/operating_company.js
+++ b/cbam/cbam/doctype/operating_company/operating_company.js
@@ -15,94 +15,103 @@ frappe.ui.form.on("Operating Company", {
             })
         }
         if(frappe.user.has_role("System Manager")){
-            frm.add_custom_button(__("Update Contact"), function(){
-            
-                let d = new frappe.ui.Dialog({
-                    "title": "Update Contact Details",
-                    fields :[
-                        {
-                            label: 'Contact Type',
-                            fieldname: 'type',
-                            fieldtype: 'Select',
-                            options: "\nCommercial Contact\nCBAM Representative",
-                            reqd: 1,
-                            onchange: function() {
-                                if(d.get_value("type")== "Commercial Contact"){
-                                    d.set_value("first_name", frm.doc.main_contact_employee_first_name)
-                                    d.set_value("email", frm.doc.main_contact_employee_email)
-                                    d.set_value("position", frm.doc.main_contact_employee_position)
-                                    d.set_value("last_name", frm.doc.main_contact_employee_last_name)
-                                    d.set_value("phone_no", frm.doc.main_contact_employee_phone_number)
+            // Only show if at least one contact is not updated (checks for '', null, or undefined)
+            const isCommercialMissing = !(frm.doc.main_contact_employee_email && frm.doc.main_contact_employee_email.trim());
+            const isCbamMissing = !(frm.doc.cbam_representive_employee_email && frm.doc.cbam_representive_employee_email.trim());
+            if(isCommercialMissing || isCbamMissing){
+                frm.add_custom_button(__("Update Contact"), function(){
+                    // Dynamically build contact type options
+                    let type_options = [];
+                    if(isCommercialMissing) type_options.push('Commercial Contact');
+                    if(isCbamMissing) type_options.push('CBAM Representative');
+
+                    let d = new frappe.ui.Dialog({
+                        "title": "Update Contact Details",
+                        fields :[
+                            {
+                                label: 'Contact Type',
+                                fieldname: 'type',
+                                fieldtype: 'Select',
+                                options: type_options.join('\n'),
+                                reqd: 1,
+                                onchange: function() {
+                                    if(d.get_value("type")== "Commercial Contact"){
+                                        d.set_value("first_name", frm.doc.main_contact_employee_first_name)
+                                        d.set_value("email", frm.doc.main_contact_employee_email)
+                                        d.set_value("position", frm.doc.main_contact_employee_position)
+                                        d.set_value("last_name", frm.doc.main_contact_employee_last_name)
+                                        d.set_value("phone_no", frm.doc.main_contact_employee_phone_number)
+                                    }
+                                    else if(d.get_value("type")== "CBAM Representative"){
+                                        d.set_value("first_name", frm.doc.cbam_representive_employee_first_name)
+                                        d.set_value("email", frm.doc.cbam_representive_employee_email)
+                                        d.set_value("position", frm.doc.cbam_representive_employee_position)
+                                        d.set_value("last_name", frm.doc.cbam_representive_last_name)
+                                        d.set_value("phone_no", frm.doc.cbam_representive_employee_phone_number)
+                                    }
                                 }
-                                else if(d.get_value("type")== "CBAM Representative"){
-                                    d.set_value("first_name", frm.doc.cbam_representive_employee_first_name)
-                                    d.set_value("email", frm.doc.cbam_representive_employee_email)
-                                    d.set_value("position", frm.doc.cbam_representive_employee_position)
-                                    d.set_value("last_name", frm.doc.cbam_representive_last_name)
-                                    d.set_value("phone_no", frm.doc.cbam_representive_employee_phone_number)
-                                }
-                            }
-                        },
-                        {
-                            fieldtype: "Section Break",
-                            depends_on: "eval:doc.type"
-                        },
-                        {
-                            label: 'First Name',
-                            fieldname: 'first_name',
-                            fieldtype: 'Data',
-                            reqd: 1
-                        },
-                        {
-                            label: 'Email',
-                            fieldname: 'email',
-                            fieldtype: 'Data',
-                            options: "Email",
-                            reqd: 1
-                        },
-                        {
-                            label: 'Position',
-                            fieldname: 'position',
-                            fieldtype: 'Data'
-                        },
-                       
-                        {
-                            fieldtype: "Column Break"
-                        },
-                        {
-                            label: 'Last Name',
-                            fieldname: 'last_name',
-                            fieldtype: 'Data',
-                            reqd: 1
-                        },
-                        {
-                            label: 'Phone No',
-                            fieldname: 'phone_no',
-                            fieldtype: 'Data'
-                        },
-                    ],
-                    size: 'large',
-                    primary_action_label: "Update Contact",
-                    primary_action(values){
-                        values.name = frm.doc.name;
-                        frappe.call({
-                            method: "update_contact",
-                            doc: frm.doc,
-                            args:{
-                                values: values
                             },
-                            freeze: true, 
-                            freeze_message: "Updating Contact Details",
-                            callback(r){
-                                msgprint("Contact Updated Successfully")
-                                d.hide()
-                                frm.reload_doc()
-                            }
-                        })
-                    }
+                            {
+                                fieldtype: "Section Break",
+                                depends_on: "eval:doc.type"
+                            },
+                            {
+                                label: 'First Name',
+                                fieldname: 'first_name',
+                                fieldtype: 'Data',
+                                reqd: 1
+                            },
+                            {
+                                label: 'Email',
+                                fieldname: 'email',
+                                fieldtype: 'Data',
+                                options: "Email",
+                                reqd: 1
+                            },
+                            {
+                                label: 'Position',
+                                fieldname: 'position',
+                                fieldtype: 'Data'
+                            },
+                           
+                            {
+                                fieldtype: "Column Break"
+                            },
+                            {
+                                label: 'Last Name',
+                                fieldname: 'last_name',
+                                fieldtype: 'Data',
+                                reqd: 1
+                            },
+                            {
+                                label: 'Phone No',
+                                fieldname: 'phone_no',
+                                fieldtype: 'Data'
+                            },
+                        ],
+                        size: 'large',
+                        primary_action_label: "Update Contact",
+                        primary_action(values){
+                            values.name = frm.doc.name;
+                            frappe.call({
+                                method: "update_contact",
+                                doc: frm.doc,
+                                args:{
+                                    values: values
+                                },
+                                freeze: true, 
+                                freeze_message: "Updating Contact Details",
+                                callback(r){
+                                    msgprint("Contact Updated Successfully")
+                                    d.hide()
+                                    frm.reload_doc()
+                                }
+                            })
+                        }
+                    })
+                    d.show()  
                 })
-                d.show()  
-            })
+            }
         }
         
 	},


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/630
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/629

**Summary -** 

- This PR enhances the Operating Company form’s user experience by making the "Update Contact" button and dialog smarter and less error-prone:
- The "Update Contact" button is now only visible to System Managers when at least one of the following contact emails is missing:
  - Commercial Contact (main_contact_employee_email)
  - CBAM Representative (cbam_representive_employee_email)

- When updating contacts, the popup will only allow selection of the contact type(s) that have not yet been entered (determined by missing email).
Ensures more robust, user-friendly handling for onboarding or updating company contacts, and prevents unintentional re-updates once both contacts are set.

