### PR TITLE
gallehr/cbam#626: Updated dashboard - various Cost Comparisons 

### DIFF
--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
@@ -29,8 +29,10 @@ def get_report_data(filters=None, selected_filters=None, start=0, page_length=50
 
 def get_columns():
     return [
+        {"fieldname": "reporting_period", "fieldtype": "Data", "label": "Reporting Period", "width": 180},
         {"fieldname": "cn_code", "fieldtype": "Data", "label": "CN Code", "width": 150},
         {"fieldname": "article_number", "fieldtype": "Data", "label": "Article Number", "width": 200},
+        {"fieldname": "data_source", "fieldtype": "Data", "label": "Data Source", "width": 180},
         {"fieldname": "supplier", "fieldtype": "Data", "label": "Supplier", "width": 200},
         {"fieldname": "raw_mass_tonne", "fieldtype": "Data", "label": "Mass [t]", "width": 150},
         {"fieldname": "installation_country", "fieldtype": "Data", "label": "Installation Country", "width": 180},
@@ -38,7 +40,7 @@ def get_columns():
         {"fieldname": "standard_emission_factor", "fieldtype": "Data", "label": "Standard Emission Factor [tCO2/t product]", "width": 220},
         {"fieldname": "standard_emission_cost", "fieldtype": "Data", "label": "Standard Cost [€]", "width": 180},
         {"fieldname": "real_emission_value", "fieldtype": "Data", "label": "Specific (Direct) Emission Value [tCO2/t product]", "width": 280},
-        {"fieldname": "real_emission_cost", "fieldtype": "Data", "label": "Cost Based on Specific Emissions [€]", "width": 280},
+        {"fieldname": "real_emission_cost", "fieldtype": "Data", "label": "Cost Based on Specific Emissions [€]", "width": 280}
     ]
 
 def get_data(filters=None, selected_filters=None, start=0, page_length=50):
@@ -159,7 +161,9 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                     IFNULL(eg.raw_mass_tonne,0.0) AS raw_mass_tonne,
                     eg.installation_country,
                     {build_cost_calculations('eg')},
-                    eg.name
+                    eg.name,
+                    'CBAM Report Data' as data_source,
+                    eg.reporting_period as reporting_period
                 FROM `tabExternal Good` eg
                 LEFT JOIN `tabCBAM Benchmark` cnb_eg 
                     ON cnb_eg.year = {year} AND cnb_eg.cn_code = eg.cn_code
@@ -174,7 +178,9 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                     IFNULL(g.raw_mass_tonne,0.0) AS raw_mass_tonne,
                     g.installation_country,    
                     {build_cost_calculations('g')},
-                    g.name
+                    g.name,
+                    'Supplier Data' as data_source,
+                    g.internal_customs_import_number as reporting_period
                 FROM `tabGood` g
                 LEFT JOIN `tabCBAM Benchmark` cnb_g 
                     ON cnb_g.year = {year} AND cnb_g.cn_code = g.cn_code
@@ -199,7 +205,9 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                     0.0 AS standard_emission_cost,
                     IFNULL(eg.specific_direct_embedded_emissions,0.0) AS real_emission_value,
                     0.0 AS real_emission_cost,
-                    eg.name
+                    eg.name,
+                    'CBAM Report Data' as data_source,
+                    eg.reporting_period as reporting_period
                 FROM `tabExternal Good` eg
                 {where_sql_eg}
                 UNION
@@ -214,7 +222,9 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                     0.0 AS standard_emission_cost,
                     IFNULL(g.specific_direct_embedded_emissions,0.0) AS real_emission_value,
                     0.0 AS real_emission_cost,
-                    g.name
+                    g.name,
+                    'Supplier Data' as data_source,
+                    g.internal_customs_import_number as reporting_period
                 FROM `tabGood` g
                 {where_sql}
             ) AS main_table
@@ -250,8 +260,8 @@ def set_conditions(declarants, filters, where_clauses, where_clauses_eg):
         where_clauses.append(f"(g.internal_customs_import_number IN ({reporting_period_list}))")
         where_clauses_eg.append(f"(eg.reporting_period IN ({reporting_period_list}))")
 
-    # Only fetch Good records with status = 'Data Submitted'
-    where_clauses.append("g.status = 'Data Submitted'")
+    # Only fetch Good records with status = 'Data Submitted' OR 'Data Assigned'
+    where_clauses.append("g.status IN ('Data Submitted', 'Data Assigned')")
 
     where_sql = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
     where_sql_eg = "WHERE " + " AND ".join(where_clauses_eg) if where_clauses_eg else ""


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/626
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/625

**Description -** 

This PR makes improvements to the “Various Cost Comparisons” page:

- Internal goods (from the Good DocType) are now displayed in the cost comparison table if their status is either "Data Submitted" or "Data Assigned" (previously, only "Data Submitted" status was included).
- Added a new “Data Source” column:
  - For internal goods, this shows “Supplier Data”.
  - For external goods, this shows “CBAM Report Data”.
- Added a “Reporting Period” column, displaying the linked reporting period for each entry (from internal_customs_import_number for internal goods, reporting_period for external goods).
- Improves transparency for end users as to where data is sourced.
- No linter errors introduced.