### PR TITLE
gallehr/cbam#628: Display and Email Detailed Missing Calculation Data

### DIFF
--- a/cbam/cbam/page/various_cost_comparisons/missing_data_email.py
+++ b/cbam/cbam/page/various_cost_comparisons/missing_data_email.py
@@ -1,0 +1,41 @@
+from frappe.utils.user import get_system_managers
+import frappe
+from cbam.cbam.page.various_cost_comparisons.various_cost_comparisons import get_report_data
+from datetime import datetime
+
+def send_missing_data_summary():
+    year = str(datetime.now().year)
+    filters = {}
+    selected_filters = {"year": year}
+    all_data = get_report_data(filters=filters, selected_filters=selected_filters, start=0, page_length=100000)["data"]
+    missing = [r for r in all_data if r.get('calculation_data_status') == "Missing"]
+    if not missing:
+        return
+    html = """
+        <b>The following rows are missing calculation data:</b>
+        <table border="1" cellpadding="6" cellspacing="0" style="border-collapse: collapse; min-width:900px;">
+        <thead>
+        <tr style="background:#f8f8f8;">
+        <th>Supplier</th>
+        <th>Article</th>
+        <th>CN</th>
+        <th>Country</th>
+        <th>Year</th>
+        <th>Missing Data</th>
+        </tr>
+        </thead>
+        <tbody>
+    """
+    for r in missing:
+        html += f"<tr>"
+        html += f"<td>{r.get('supplier', '')}</td>"
+        html += f"<td>{r.get('article_number', '')}</td>"
+        html += f"<td>{r.get('cn_code', '')}</td>"
+        html += f"<td>{r.get('installation_country', '')}</td>"
+        html += f"<td>{year}</td>"
+        html += f"<td style='color:#d97a12;font-weight:600'>{r.get('missing_data_reason', '')}</td>"
+        html += f"</tr>"
+    html += "</tbody></table>"
+    recipients = get_system_managers()
+    frappe.sendmail(recipients=recipients, subject="[CBAM] Missing Calculation Data", content=html)
+    frappe.db.commit()

--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.js
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.js
@@ -542,17 +542,7 @@ frappe.pages['various-cost-comparisons'].on_page_load = function(wrapper) {
                         } else {
                             datatable.refresh(table_data);
                         }
-                        // Show popup if any missing
-                        if (missingRows.length > 0 && !missingDataPopupShown) {
-                            console.log('Showing missing calculation data popup (first and only time per table load)');
-                            let popupMsg = '<b>The following rows are missing calculation data:</b><ul>';
-                            missingRows.forEach((r) => {
-                              popupMsg += `<li>Supplier: <b>${r.supplier||''}</b>, Article: <b>${r.article_number||''}</b>, CN: <b>${r.cn_code||''}</b>, Country: <b>${r.installation_country||''}</b>, Year: <b>${filters.year?.get_value()||''}</b>: <span style=\"color:#b8860b\">${r.missing_data_reason}</span></li>`;
-                            });
-                            popupMsg += '</ul>';
-                            frappe.msgprint({title: 'Missing Calculation Data', indicator: 'orange', message: popupMsg, wide: true});
-                            missingDataPopupShown = true; // Set to true so popup does not repeat
-                        }
+                        
                         // Update chart (respect 'Show Selected rows' toggle)
                         const showSelected = $('#selected-rows-toggle').is(':checked');
                         let chart_data_final;

--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
@@ -23,9 +23,9 @@ def get_report_data(filters=None, selected_filters=None, start=0, page_length=50
 
     columns = get_columns()
 
-    data, total_count, missing_summary = get_data(filters, selected_filters, start, page_length)
+    data, total_count = get_data(filters, selected_filters, start, page_length)
     chart_data = get_chart_data(data)
-    return {"columns": columns, "data": data, "chart_data": chart_data, "total_count": total_count, "missing_summary": missing_summary}
+    return {"columns": columns, "data": data, "chart_data": chart_data, "total_count": total_count}
 
 
 def get_columns():
@@ -41,7 +41,8 @@ def get_columns():
         {"fieldname": "standard_emission_factor", "fieldtype": "Data", "label": "Standard Emission Factor [tCO2/t product]", "width": 220},
         {"fieldname": "standard_emission_cost", "fieldtype": "Data", "label": "Standard Cost [€]", "width": 180},
         {"fieldname": "real_emission_value", "fieldtype": "Data", "label": "Specific (Direct) Emission Value [tCO2/t product]", "width": 280},
-        {"fieldname": "real_emission_cost", "fieldtype": "Data", "label": "Cost Based on Specific Emissions [€]", "width": 280}
+        {"fieldname": "real_emission_cost", "fieldtype": "Data", "label": "Cost Based on Specific Emissions [€]", "width": 280},
+        {"fieldname": "calculation_data_status", "fieldtype": "Data", "label": "Calculation Data", "width": 140},
     ]
 
 def get_data(filters=None, selected_filters=None, start=0, page_length=50):
@@ -235,35 +236,19 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
 
     required_fields = [
         ("cbam_benchmark", "CBAM Benchmark"),
-        ("standard_emission_factor", "Standard Emission Value")
+        ("standard_emission_factor", "Standard Emission Value"),
+        ("real_emission_value", "Specific Direct Emission Value"),
     ]
-    missing_summary = []
     for row in data:
         missing = []
         for key, label in required_fields:
-            if not row.get(key):
+            val = row.get(key)
+            if is_missing(val):
                 missing.append(label)
-        if missing:
-            row['missing_data_reason'] = f"Missing: {', '.join(missing)}"
-            row['missing_fields'] = missing
-            missing_summary.append({
-                "cn_code": row.get("cn_code"),
-                "country": row.get("installation_country"),
-                "year": selected_filters.get("year"),
-                "article_number": row.get("article_number"),
-                "supplier": row.get("supplier"),
-                "missing": missing
-            })
-
-    if missing_summary:
-        user_emails = get_system_managers()  # returns a list of email ids
-        msg = "Some lines in Financial Dashboard are missing calculation data:\n\n" + '\n'.join([
-            f"Supplier: {entry.get('supplier', '')}, Article: {entry.get('article_number', '')}, CN {entry['cn_code']}, Country {entry.get('country')}, Year {entry.get('year')} → Missing: {', '.join(entry['missing'])}" for entry in missing_summary
-        ])
-        frappe.sendmail(recipients=user_emails, subject="Financial Dashboard: Missing Calculation Data", message=msg)
-
-    return data, total_count, missing_summary
-
+        row['calculation_data_status'] = "<span style='color:#d97a12;font-weight:600'>Missing</span>" if missing else "<span style='color:#1f77b4;font-weight:600'>Available</span>"
+        row['missing_data_reason'] = ", ".join(missing) if missing else ""
+    
+    return data, total_count
 
 def set_conditions(declarants, filters, where_clauses, where_clauses_eg):
     if declarants:
@@ -535,3 +520,9 @@ def get_latest_ets_price(year=None, ets_price_type=None):
     result = frappe.db.sql(sql, sql_params, as_dict=True)
     
     return result[0] if result else None
+
+def is_missing(val):
+    try:
+        return val is None or str(val).strip() in ("", "0", "0.0")
+    except Exception:
+        return True

--- a/cbam/hooks.py
+++ b/cbam/hooks.py
@@ -186,6 +186,9 @@ scheduler_events = {
     },
     "daily":[
         "cbam.utils.ets_import.scheduled_import.scheduled_ets_import"
+    ],
+    "daily": [
+        "cbam.cbam.page.various_cost_comparisons.missing_data_email.send_missing_data_summary"
     ]
 }
 


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/628#note_43239
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/627

**Summary -** 

- Adds a “Calculation Data” column to the financial dashboard report table, showing "Available" or "Missing (...fields...)" for each row.
- When data is missing, the exact missing fields (e.g., CBAM Benchmark, Standard Emission Value) are displayed directly in the table for transparency and easy review.
- The pop-up for missing calculation data is removed, improving user experience.
- Introduces a scheduled daily email to all system managers with a detailed, well-formatted HTML table of all rows currently missing calculation data.
- Ensures the email checks all data for the current year, without pagination, so every missing case is notified.
- Robust backend logic treats all forms of missing/zero values (None, 0, '0', etc.) as missing for critical fields.
- Improves maintainability and user clarity for validating master data completeness within the CBAM financial dashboard.