### PR TITLE
gallehr/cbam#634: disabled reporting period from CBAM Benchmark

### DIFF
--- a/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.json
+++ b/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.json
@@ -40,6 +40,7 @@
   {
    "fieldname": "reporting_period",
    "fieldtype": "Table MultiSelect",
+   "hidden": 1,
    "label": "Reporting Period",
    "options": "Reporting Period"
   },
@@ -53,7 +54,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-09 07:56:12.685414",
+ "modified": "2025-10-21 12:59:21.138612",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "CBAM Benchmark",


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/634#note_43246
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/633

Summary - 

Disabled field "reporting period (Multiselect)" from doctype "CBAM Benchmark"