### PR TITLE
gallehr/cbam#645: Add upload option for attachments in Emissions

### DIFF
--- a/cbam/cbam/doctype/cbam_emission_data/cbam_emission_data.json
+++ b/cbam/cbam/doctype/cbam_emission_data/cbam_emission_data.json
@@ -29,6 +29,7 @@
   "column_break_iywy",
   "production_method",
   "electricity_consumed",
+  "emission_attachment",
   "goods_covered_by_this_emissions_calculation_section",
   "cn_codes"
  ],
@@ -178,12 +179,17 @@
    "fieldtype": "Small Text",
    "label": "Emission Notes",
    "mandatory_depends_on": "eval:!doc.specific_direct_embedded_emissions"
+  },
+  {
+   "fieldname": "emission_attachment",
+   "fieldtype": "Attach",
+   "label": "Emission Attachment"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-08 12:32:50.259818",
+ "modified": "2025-10-24 12:03:02.705364",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "CBAM Emission Data",

--- a/cbam/cbam/doctype/cbam_emission_data/cbam_emission_data.py
+++ b/cbam/cbam/doctype/cbam_emission_data/cbam_emission_data.py
@@ -4,10 +4,34 @@
 import frappe
 from frappe.model.document import Document
 
-
+from cbam.utils import rename_any_file
 class CBAMEmissionData(Document):
 	def on_update(self):
 		self.update_good_installation_name()
+		if self.emission_attachment:
+			oc = self.operating_company or "OC-UNKNOWN"
+			supplier = getattr(self, "supplier", None) or "NOSUPPLIER"
+			original_file = self.emission_attachment.split('/')[-1]
+			expected_prefix = f"{oc}_{supplier}_"
+
+			# Only rename if current filename does not match target pattern exactly once
+			already_correct = original_file.startswith(expected_prefix)
+			prefix_count = original_file.count(expected_prefix)
+			if already_correct and prefix_count == 1:
+				return
+
+			# Remove all leading known prefixes before applying target prefix
+			base_name = original_file
+			while base_name.startswith(expected_prefix):
+				base_name = base_name[len(expected_prefix):]
+			new_file_name = f"{expected_prefix}{base_name}"
+			if original_file == new_file_name:
+				return  # exactly same name--nothing to do
+				
+			result = rename_any_file(self.emission_attachment, new_file_name)
+			if result and isinstance(result, dict) and "file_url" in result:
+				frappe.db.set_value("CBAM Emission Data", self.name, "emission_attachment", result["file_url"])
+				frappe.db.commit()
 		
 	def after_insert(self):
 		self.add_to_installation_cht()

--- a/cbam/cbam/doctype/good/good.js
+++ b/cbam/cbam/doctype/good/good.js
@@ -69,5 +69,17 @@ frappe.ui.form.on("Good", {
                 }
             });
         });
+        if (frm.doc.emission_data_attachment) {
+            let path = frm.doc.emission_data_attachment;
+            // Always show as clickable if path starts with /files/ or /private/files/
+            if ((path.startsWith('/files/') || path.startsWith('/private/files/'))) {
+                let file_name = path.split('/').pop();
+                let html = `<a href="${path}" target="_blank">${file_name}</a>`;
+                frm.fields_dict.emission_data_attachment.$wrapper.html(html);
+            } else {
+                // fallback, show as plain text or non-clickable
+                frm.fields_dict.emission_data_attachment.$wrapper.html(path);
+            }
+        }
     },
 });

--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -560,6 +560,12 @@
    "read_only": 1
   },
   {
+   "fieldname": "emission_data_attachment",
+   "fieldtype": "Read Only",
+   "label": "Emission Data Attachment",
+   "fetch_from": "emission_data.emission_attachment"
+  },
+  {
    "fieldname": "column_break_fdty",
    "fieldtype": "Column Break"
   },

--- a/cbam/hooks.py
+++ b/cbam/hooks.py
@@ -171,6 +171,9 @@ doc_events = {
     },
     "User": {
         "before_save": "cbam.override.user.update_operating_company_contact"
+    },
+    "File": {
+        "on_trash": "cbam.utils.utils.prevent_declarant_file_delete"
     }
 }
 

--- a/cbam/templates/includes/footer/footer_links.html
+++ b/cbam/templates/includes/footer/footer_links.html
@@ -9,7 +9,7 @@
 {% endmacro %}
 <div class="footer-links">
 	<div class="row">
-		<div class="footer-col-left col-sm-6" style="text-align: justify">
+		<div class="footer-col-left col-sm-11" style="text-align: justify">
 			<a class="footer-link" href="/imprint" rel="noreferrer">{{_('Impressum')}}</a>
 			<a class="footer-link" href="/privacy-policy" rel="noreferrer">{{_('Privacy Policy')}}</a><br>
 			<p style="font-size: 11px;">

--- a/cbam/templates/installation_partial.html
+++ b/cbam/templates/installation_partial.html
@@ -128,6 +128,7 @@
 				<td><strong>{{_('Electricity Emission Factor [tCO2/MWh]')}}</strong></td>
 				<td><strong>{{_('Source of Electricity Emission Factor')}}</strong></td>
 				<td><strong>{{_('Specific (Indirect) Embedded Emissions [tCO2/t]')}}</strong></td>
+				<td><strong>{{_('Emission Attachment')}}</strong></td>
 				<td><strong>{{_('Edit Emission')}}</strong></td>
 			</tr>
 			
@@ -144,6 +145,11 @@
 				<td>{{i.indirect_emission_factor}}</td>
 				<td>{{i.source_of_indirect_emission_factor or ""}}</td>
 				<td>{{i.specific_indirect_embedded_emissions or ""}}</td>
+				<td>
+              {% if i.emission_attachment %}
+                <a href="{{ i.emission_attachment }}" target="_blank">{{ i.emission_attachment.split('/')[-1] }}</a>
+              {% else %}-{% endif %}
+            </td>
 				<td style="text-align: center;">
 				<button class="btn btn-secondary btn-sm secondary-action edit-emission" data-emission="{{i.name}}">
 					{{_('Edit')}}

--- a/cbam/utils/__init__.py
+++ b/cbam/utils/__init__.py
@@ -1,20 +1,55 @@
 import frappe
 import json
+import os
+
+def _link_and_prefix_emission_attachment(doc_dict, doc_obj):
+    if doc_dict.get("doctype") == "CBAM Emission Data" and doc_dict.get("emission_attachment"):
+        file_url = doc_dict["emission_attachment"]
+        oc_ref = None
+        supplier = "NOSUPPLIER"
+        if hasattr(doc_obj, 'operating_company') and doc_obj.operating_company:
+            oc_doc = frappe.get_doc("Operating Company", doc_obj.operating_company)
+            oc_ref = oc_doc.name
+            supplier = getattr(oc_doc, "supplier", None) or "NOSUPPLIER"
+        else:
+            oc_ref = "OC-UNKNOWN"
+
+        file_doc = frappe.get_all("File", filters={"file_url": file_url}, fields=["name", "file_name", "file_url"])
+        if file_doc:
+            file_doc = frappe.get_doc("File", file_doc[0].name)
+            expected_prefix = f"{oc_ref}_{supplier}_"
+            if not file_doc.file_name.startswith(expected_prefix):
+                new_name = f"{expected_prefix}{file_doc.file_name}"
+                if file_doc.file_url and file_doc.file_url.startswith("/files/"):
+                    old_url = file_doc.file_url
+                    new_url = f"/files/{expected_prefix}{file_doc.file_name}"
+                    # Get actual filesystem path to files directory
+                    site_public = frappe.get_site_path("public")
+                    old_path = os.path.join(site_public, old_url.lstrip("/"))
+                    new_path = os.path.join(site_public, new_url.lstrip("/"))
+                    os.rename(old_path, new_path)
+                    file_doc.file_url = new_url
+                file_doc.file_name = new_name
+            file_doc.attached_to_doctype = "CBAM Emission Data"
+            file_doc.attached_to_name = doc_obj.name
+            file_doc.save(ignore_permissions=True)
 
 @frappe.whitelist()
 def create_new_doc(doc):
     doc = json.loads(doc)
-    return frappe.get_doc(doc).insert(ignore_permissions=True)
+    doc_obj = frappe.get_doc(doc).insert(ignore_permissions=True)
+    _link_and_prefix_emission_attachment(doc, doc_obj)
+    return doc_obj
 
 @frappe.whitelist()
 def update_doc(doc):
     doc = json.loads(doc)
     if not frappe.db.exists(doc.get("doctype"), doc.get("name")):
         frappe.throw("Document doesn't exist")
-    
     existing_doc = frappe.get_doc(doc.get("doctype"), doc.get("name"))
     existing_doc.update(doc)
     existing_doc.save(ignore_permissions=True)
+    _link_and_prefix_emission_attachment(doc, existing_doc)
     return existing_doc
 
 @frappe.whitelist()
@@ -37,3 +72,40 @@ def get_field_options(doc, fieldname):
     if field and field.options:
         return field.options.split("\n")
     return []
+
+@frappe.whitelist()
+def rename_any_file(file_url, new_file_name):
+    """Rename a file (public or private) and update its File DocType record's file_url and file_name."""
+    if not file_url or not new_file_name:
+        frappe.throw('Both file_url and new_file_name are required.')
+
+    if file_url.startswith("/private/files/"):
+        site_path = frappe.get_site_path("private")
+        # both source and target in private
+        old_path = os.path.join(site_path, "files", file_url.split("/")[-1])
+        new_url = f"/private/files/{new_file_name}"
+        new_path = os.path.join(site_path, "files", new_file_name)
+    elif file_url.startswith("/files/"):
+        site_path = frappe.get_site_path("public")
+        old_path = os.path.join(site_path, file_url.lstrip('/'))
+        new_url = f"/files/{new_file_name}"
+        new_path = os.path.join(site_path, new_url.lstrip('/'))
+    else:
+        frappe.throw("File URL must be public (/files/) or private (/private/files/).")
+
+    # Move file on disk
+    if not os.path.exists(old_path):
+        frappe.throw(f"File to rename not found: {old_path}")
+    os.rename(old_path, new_path)
+
+    # Update File DocType
+    file_docs = frappe.get_all("File", filters={"file_url": file_url}, fields=["name"])
+    if file_docs:
+        file_doc = frappe.get_doc("File", file_docs[0].name)
+        file_doc.file_name = new_file_name
+        file_doc.file_url = new_url
+        file_doc.save(ignore_permissions=True)
+        frappe.db.commit()
+        return {'file_url': new_url, 'file_name': new_file_name}
+    else:
+        frappe.throw('File record not found for given URL.')

--- a/cbam/utils/utils.py
+++ b/cbam/utils/utils.py
@@ -98,3 +98,7 @@ def get_declarant_for_user():
     )
     return declarants
 
+def prevent_declarant_file_delete(doc, method=None):
+    # Only block for CBAM Emission Data
+    if doc.attached_to_doctype == "CBAM Emission Data" and "Declarant" in frappe.get_roles():
+        frappe.throw("Declarant is not allowed to delete attachments for CBAM Emission Data.")

--- a/cbam/www/installation_list/index.js
+++ b/cbam/www/installation_list/index.js
@@ -415,8 +415,14 @@ function executeJS() {
                     fieldname: "cb2",
                     fieldtype: "Column Break",
                 },
-
-
+                {
+                    label: __("Upload Attachment"),
+                    fieldname: "emission_attachment",
+                    fieldtype: "Attach",
+                    reqd: false,
+                    description: "Attach supporting file for this emission (PDF, DOC, etc.)",
+                    default: docData ? docData.emission_attachment : ""
+                },
             ],
             size: 'extra-large', // small, large, extra-large 
             primary_action_label: `${update ? __("Update Emission") : __("Create Emission")}`,


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/645
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/596

Summary:

**1. Website Users: Attachments on Create/Edit**

- Users can upload attachments when creating or editing emission records using an intuitive "Upload Attachment" field.

**2. Automatic Naming Convention**

- Uploaded files are automatically renamed with a prefix:
- OC-xxxxxx_supplier-attachment-name.pdf
- ("OC" = Operating Company Reference, "supplier" = supplier code, original filename follows).
- This renaming is robust, enforced on every create/update, and only performed if the correct prefix is missing (prefixes are never doubled).

**3. Reliable Download and Visibility**

- The attachment link shown in the Emissions Doctype (Desk and website) is always updated to match the actual stored filename and location.
- Users can always access and download the correct file regardless of renaming or system changes.

**4. Declarant Permission Enforcement**

- Declarant users are prevented from deleting attachments (including via the Desk sidebar or API) if the file is attached to a CBAM Emission record.
  - Attempting to delete triggers a backend validation and the operation is blocked.
- (For even stricter security, this event hook can be further activated in system settings or customized for other roles as needed.)

**5. Attachment Display in Goods (Emission Section)**

- The actual file name of each emission attachment is visibly listed in the relevant section for the user,
  - Shown as a clickable download link.
  - Field uses the correct label (“Attachment”) and gives immediate feedback about the current file.

**6. Security and Compliance**
The naming and permission logic ensure auditability, prevents accidental file overwrites, and aligns with best practices for data integrity and user role separation.