### PR TITLE
gallehr/cbam#646: enable horizontal scroll in card display

### DIFF
--- a/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.js
+++ b/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.js
@@ -26,7 +26,18 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
             height: 60px;
         }
         #annual-exposure-cards{
-            height: 60px;
+            height: auto;
+        }
+        .frappe-card:has(#annual-exposure-cards) {
+            scrollbar-width: thin;
+            scrollbar-color: #e3e3e3 #f8f9fa;
+        }
+        .frappe-card:has(#annual-exposure-cards)::-webkit-scrollbar {
+            height: 8px;
+        }
+        .frappe-card:has(#annual-exposure-cards)::-webkit-scrollbar-thumb {
+            background: #e3e3e3;
+            border-radius: 4px;
         }
         #dashboard-tabs .nav-link.active {
           background-color: #000 !important;
@@ -42,6 +53,18 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
           margin-left: 0 !important;
           margin-right: 0 !important;
           margin-bottom: 25px !important;
+        }
+        #annual-exposure-cards {
+            // margin-bottom: 32px !important;
+            position: relative;
+            z-index: 2;
+            background: #fff !important;
+            border-radius: 8px;
+        }
+        #chart-section-container {
+            position: relative;
+            margin-top: 16px !important;
+            z-index: 1;
         }
       </style>`).appendTo('head');
   
@@ -91,8 +114,8 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                 </div>
 
                 <!-- Annual Exposure Stat Cards -->
-                <div class="frappe-card mb-3 p-2">
-                    <div class="d-flex flex-wrap" id="annual-exposure-cards" style="gap: 16px;">
+                <div class="frappe-card mb-3 p-2" style="overflow-x: auto; overflow-y: hidden; padding: 8px !important;">
+                    <div class="d-flex flex-nowrap" id="annual-exposure-cards" style="gap: 16px; min-width: fit-content; margin: 0;">
                         <!-- Cards will be populated dynamically -->
                     </div>
                 </div>

--- a/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py
+++ b/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py
@@ -494,8 +494,8 @@ def get_available_years():
     user_roles = frappe.get_roles(user)
     is_system_manager = 'System Manager' in user_roles
     filters = {}
+    # Only filter by Declarant if user has explicit restrictions
     if not is_system_manager:
-        # Try to find a declarant linked to this user
         declarant = frappe.db.get_value("Declarant", {"email": user}, "name")
         if declarant:
             filters["declarant"] = declarant
@@ -541,15 +541,19 @@ def get_cbam_reports_by_year(year):
     """Get CBAM reports for a specific year based on from_date and to_date"""
     user = frappe.session.user
     
-    # Check if user is a System Manager
+    # Filter by user permissions if not System Manager
     user_roles = frappe.get_roles(user)
     is_system_manager = 'System Manager' in user_roles
+    
     filters = {}
+    
+    # Only filter by Declarant if user has explicit restrictions (not all non-managers)
     if not is_system_manager:
-        # Try to find a declarant linked to this user
+        # Check if user has limited scope
         declarant = frappe.db.get_value("Declarant", {"email": user}, "name")
         if declarant:
             filters["declarant"] = declarant
+    # System Managers and users with broader access see all reports
     
     # Add year filter using from_date and to_date
     year = int(year)


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/646
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/642

**Summary -**

- Added overflow-x: auto to the parent frappe-card container to enable horizontal scrolling when cards exceed container width.
- Switched the inner cards container from flex-wrap to flex-nowrap to prevent wrapping and keep all cards in a single horizontal row.
- Added min-width: fit-content to the cards row to ensure proper width calculation.
- Adjusted padding on frappe-card from default to 8px to reduce white space and optimize container height.

<img width="2762" height="754" alt="image" src="https://github.com/user-attachments/assets/d8f21639-2bab-4465-b699-a3f2f9d95f35" />
