### PR TITLE
gallehr/cbam#645: fixed - hide public/private button

### DIFF
--- a/cbam/www/installation_list/index.html
+++ b/cbam/www/installation_list/index.html
@@ -1,7 +1,11 @@
 {% extends "templates/cbamweb.html" %}
 
 
-
+{% block header %}
+<style>
+  .modal-footer .btn-secondary { display: none !important; }
+</style>
+{% endblock %}
 
 {% block page_content %}
 {% include "templates/includes/web_sidebar.html" %}

--- a/cbam/www/installation_list/index.js
+++ b/cbam/www/installation_list/index.js
@@ -24,9 +24,6 @@ frappe.ready(() => {
 });
 // end of translation
   
-
-  
-
 window.addEventListener("DOMContentLoaded", () => {
     executeJS();
     refreshElements(frappe)
@@ -421,7 +418,10 @@ function executeJS() {
                     fieldtype: "Attach",
                     reqd: false,
                     description: "Attach supporting file for this emission (PDF, DOC, etc.)",
-                    default: docData ? docData.emission_attachment : ""
+                    default: docData ? docData.emission_attachment : "",
+                    options: {
+                        allow_toggle_private: false
+                    }
                 },
             ],
             size: 'extra-large', // small, large, extra-large 
@@ -442,6 +442,7 @@ function executeJS() {
             }
         });          
         d.show();
+
 
         // This is to recalculate the indirect emissions when the electricity consumed or indirect emission factor changes
         d.fields_dict.electricity_consumed.df.change = function() {


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/645
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/596

Summary - 

Improves the attachment upload UX in the “Add/Update Emission” dialog on the Installation List page by:

- Hiding the uploader modal’s “Set all public/private” secondary button (page-scoped)
- Disabling the per-file “Private” toggle in the Attach field using the supported FileUploader option



https://github.com/user-attachments/assets/3b7c6586-ce05-469e-b35b-f33ec9493221

