### PR TITLE
gallehr/cbam#646: updated highchart

### DIFF
--- a/cbam/cbam/page/ets_price_dashboard/ets_price_dashboard.js
+++ b/cbam/cbam/page/ets_price_dashboard/ets_price_dashboard.js
@@ -42,16 +42,37 @@ frappe.pages['ets-price-dashboard'].on_page_load = function(wrapper) {
         </ul>
     `);
 
-    // Ensure Highcharts is loaded
-    if (typeof Highcharts === 'undefined') {
-        var script = document.createElement('script');
-        script.src = 'https://code.highcharts.com/highcharts.js';
-        script.onload = function() {
-            // After loading, re-render chart if data is present
-            if (allData && allData.length) renderChart(allData);
-        };
-        document.head.appendChild(script);
+    // Use centralized Highcharts loader to prevent conflicts when navigating between pages
+    // With fallback if cbam.utils is not available
+    function loadHighchartsForDashboard() {
+        if (typeof cbam !== 'undefined' && typeof cbam.utils !== 'undefined' && typeof cbam.utils.loadHighcharts === 'function') {
+            cbam.utils.loadHighcharts((error) => {
+                if (error) {
+                    console.error('Highcharts load error:', error);
+                } else {
+                    // After loading, re-render chart if data is present
+                    if (allData && allData.length) renderChart(allData);
+                }
+            });
+        } else {
+            // Fallback: direct loading if utils not available
+            if (typeof Highcharts === 'undefined') {
+                var script = document.createElement('script');
+                script.src = 'https://code.highcharts.com/highcharts.js';
+                script.onload = function() {
+                    if (allData && allData.length) renderChart(allData);
+                };
+                script.onerror = function() {
+                    console.error('Failed to load Highcharts');
+                };
+                document.head.appendChild(script);
+            } else {
+                if (allData && allData.length) renderChart(allData);
+            }
+        }
     }
+    
+    loadHighchartsForDashboard();
 
     // Add filter section above the chart
     $(page.body).append(`
@@ -433,7 +454,8 @@ frappe.pages['ets-price-dashboard'].on_page_load = function(wrapper) {
                 }
             },
             series: series,
-            credits: { enabled: false }
+            credits: { enabled: false },
+            accessibility: { enabled: false }
         });
     }
 

--- a/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.js
+++ b/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.js
@@ -27,6 +27,11 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
         }
         #annual-exposure-cards{
             height: 60px;
+            overflow-x: auto;
+            overflow-y: hidden;
+        }
+        .frappe-card:has(#annual-exposure-cards) {
+            overflow-x: auto;
         }
         #dashboard-tabs .nav-link.active {
           background-color: #000 !important;
@@ -92,7 +97,7 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
 
                 <!-- Annual Exposure Stat Cards -->
                 <div class="frappe-card mb-3 p-2">
-                    <div class="d-flex flex-wrap" id="annual-exposure-cards" style="gap: 16px;">
+                    <div class="d-flex flex-nowrap" id="annual-exposure-cards" style="gap: 16px;">
                         <!-- Cards will be populated dynamically -->
                     </div>
                 </div>
@@ -767,8 +772,42 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
         if (Array.isArray(chart_data.series)) {
             chart_data.series.forEach(s => { s.data = ensureObjectPoints(s.data); });
         }
+        // Destroy existing chart if present to prevent error #16 (Highcharts already defined)
+        const chartContainer = document.getElementById('chart-section');
+        if (!chartContainer) {
+            console.error('Chart container not found');
+            return;
+        }
+        
+        // Destroy existing Highcharts instance if present
+        if (chartContainer._highchartsInstance) {
+            try {
+                chartContainer._highchartsInstance.destroy();
+            } catch(e) {
+                console.warn('Error destroying existing chart:', e);
+            }
+        }
+        
+        // Also check Highcharts.charts array for existing charts on this container
+        if (typeof window.Highcharts !== 'undefined' && window.Highcharts.charts) {
+            window.Highcharts.charts.forEach((chart, index) => {
+                if (chart && chart.renderTo && chart.renderTo.id === 'chart-section') {
+                    try {
+                        chart.destroy();
+                    } catch(e) {
+                        console.warn('Error destroying chart from Highcharts.charts:', e);
+                    }
+                }
+            });
+        }
+        
+        // Clear container content
+        chartContainer.innerHTML = '';
+        
         // Do NOT touch overlays/diamonds logic at all
-        Highcharts.chart('chart-section', {
+        let chartInstance;
+        try {
+            chartInstance = Highcharts.chart('chart-section', {
             chart: {
                 type: 'column',
                 height: 600,
@@ -776,6 +815,7 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                 spacingBottom: 20 // reduced from 100
             },
             credits: { enabled: false },
+            accessibility: { enabled: false },
             title: { text: 'Financial Exposure Forecast' },
             xAxis: {
                 categories: categories,
@@ -1043,7 +1083,24 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
                     fontSize: '12px'
                 }
             }
-        });
+            });
+        } catch (error) {
+            console.error('Highcharts error:', error);
+            // Highcharts error #16: Highcharts already defined
+            // This typically means Highcharts is loaded multiple times or there's a conflict
+            if (error.message && (error.message.includes('16') || error.message.includes('already defined'))) {
+                console.warn('Highcharts conflict detected. Please refresh the page to resolve.');
+                $('#chart-section').html('<div class="text-center text-warning p-4">Chart library conflict detected. Please refresh the page.</div>');
+            } else {
+                $('#chart-section').html('<div class="text-center text-danger p-4">Chart rendering error. Please refresh the page.</div>');
+            }
+            return;
+        }
+        
+        // Store chart instance reference for cleanup
+        if (chartInstance && chartContainer) {
+            chartContainer._highchartsInstance = chartInstance;
+        }
         
         // Populate annual exposure stat cards
         populateAnnualExposureCards(accumulatedExposureMonth, categories);
@@ -1103,15 +1160,83 @@ frappe.pages['financial-exposure-forecast'].on_page_load = function(wrapper) {
             });
     }
 
-    // Loader for Highcharts
+    // Use centralized Highcharts loader from cbam.utils with fallback
     function load_highcharts(callback) {
-        if (typeof Highcharts !== 'undefined') {
-            callback();
+        // Ensure cbam.utils is available (wait if needed)
+        if (typeof cbam === 'undefined' || typeof cbam.utils === 'undefined' || typeof cbam.utils.loadHighcharts !== 'function') {
+            // Fallback: wait for bundle to load, then try again
+            let checkCount = 0;
+            const maxChecks = 50; // 5 seconds max wait
+            const checkInterval = setInterval(() => {
+                checkCount++;
+                if (typeof cbam !== 'undefined' && typeof cbam.utils !== 'undefined' && typeof cbam.utils.loadHighcharts === 'function') {
+                    clearInterval(checkInterval);
+                    cbam.utils.loadHighcharts((error) => {
+                        if (error) {
+                            console.error('Highcharts load error:', error);
+                            $('#chart-section').html('<div class="text-center text-danger p-4">Chart library failed to load. Please refresh the page.</div>');
+                        } else {
+                            callback();
+                        }
+                    });
+                } else if (checkCount >= maxChecks) {
+                    clearInterval(checkInterval);
+                    console.error('cbam.utils.loadHighcharts not available, using fallback loader');
+                    // Fallback to direct loading
+                    load_highcharts_fallback(callback);
+                }
+            }, 100);
             return;
         }
+        
+        // Use centralized loader
+        cbam.utils.loadHighcharts((error) => {
+            if (error) {
+                console.error('Highcharts load error:', error);
+                $('#chart-section').html('<div class="text-center text-danger p-4">Chart library failed to load. Please refresh the page.</div>');
+            } else {
+                callback();
+            }
+        });
+    }
+    
+    // Fallback loader if cbam.utils is not available
+    function load_highcharts_fallback(callback) {
+        if (typeof window.Highcharts !== 'undefined' && typeof window.Highcharts.chart === 'function') {
+            setTimeout(callback, 0);
+            return;
+        }
+        
+        const existingScript = document.querySelector('script[src*="highcharts.js"]');
+        if (existingScript) {
+            let checkCount = 0;
+            const maxChecks = 50;
+            const checkInterval = setInterval(() => {
+                checkCount++;
+                if (typeof window.Highcharts !== 'undefined' && typeof window.Highcharts.chart === 'function') {
+                    clearInterval(checkInterval);
+                    setTimeout(callback, 100);
+                } else if (checkCount >= maxChecks) {
+                    clearInterval(checkInterval);
+                    $('#chart-section').html('<div class="text-center text-danger p-4">Chart library failed to load. Please refresh the page.</div>');
+                }
+            }, 100);
+            return;
+        }
+        
         const script = document.createElement('script');
         script.src = 'https://code.highcharts.com/highcharts.js';
-        script.onload = callback;
+        script.async = true;
+        script.onload = () => {
+            if (typeof window.Highcharts !== 'undefined' && typeof window.Highcharts.chart === 'function') {
+                setTimeout(callback, 100);
+            } else {
+                $('#chart-section').html('<div class="text-center text-danger p-4">Chart library failed to initialize. Please refresh the page.</div>');
+            }
+        };
+        script.onerror = () => {
+            $('#chart-section').html('<div class="text-center text-danger p-4">Failed to load chart library. Please refresh the page.</div>');
+        };
         document.head.appendChild(script);
     }
     function update_export_button_state() {

--- a/cbam/cbam/page/various_cost_comparisons/chart.js
+++ b/cbam/cbam/page/various_cost_comparisons/chart.js
@@ -53,6 +53,7 @@ cbam.update_chart = function update_chart(chart_data) {
             credits: {
                 enabled: false
             },
+            accessibility: { enabled: false },
             title: { text: __('Cost Exposure of Articles @ [selected ETS Price basis]') },
             xAxis: {
                 categories: labels,
@@ -81,13 +82,33 @@ cbam.update_chart = function update_chart(chart_data) {
         });
     }
 
-    if (typeof window.Highcharts === 'undefined') {
-        // Dynamically load Highcharts from CDN if not already loaded
-        const script = document.createElement('script');
-        script.src = 'https://code.highcharts.com/highcharts.js';
-        script.onload = () => renderHighChart();
-        document.head.appendChild(script);
-    } else {
-        renderHighChart();
+    // Use centralized Highcharts loader to prevent conflicts when navigating between pages
+    // With fallback if cbam.utils is not available
+    function loadChart() {
+        if (typeof cbam !== 'undefined' && typeof cbam.utils !== 'undefined' && typeof cbam.utils.loadHighcharts === 'function') {
+            cbam.utils.loadHighcharts((error) => {
+                if (error) {
+                    console.error('Highcharts load error:', error);
+                    $('#chart-section').html('<div class="text-center text-danger p-4">Chart library failed to load. Please refresh the page.</div>');
+                } else {
+                    renderHighChart();
+                }
+            });
+        } else {
+            // Fallback: direct loading if utils not available
+            if (typeof window.Highcharts === 'undefined') {
+                const script = document.createElement('script');
+                script.src = 'https://code.highcharts.com/highcharts.js';
+                script.onload = () => renderHighChart();
+                script.onerror = () => {
+                    $('#chart-section').html('<div class="text-center text-danger p-4">Chart library failed to load. Please refresh the page.</div>');
+                };
+                document.head.appendChild(script);
+            } else {
+                renderHighChart();
+            }
+        }
     }
+    
+    loadChart();
 }

--- a/cbam/public/js/web/utils.js
+++ b/cbam/public/js/web/utils.js
@@ -103,6 +103,144 @@ $.extend(cbam.utils, {
 
     },
     
+    /**
+     * Centralized Highcharts loader to prevent duplicate loading and conflicts
+     * Used by: Financial Exposure Forecast, Various Cost Comparisons, ETS Price Dashboard
+     * 
+     * This loader handles all edge cases:
+     * - Prevents duplicate script loading
+     * - Handles race conditions
+     * - Waits for existing loads to complete
+     * - Verifies Highcharts is fully initialized
+     * - Handles CDN failures gracefully
+     */
+    loadHighcharts(callback) {
+        // Debug logging (can be removed in production)
+        const DEBUG = false; // Set to true for debugging client issues
+        
+        if (DEBUG) {
+            console.log('[Highcharts Loader] Starting load check', {
+                HighchartsExists: typeof window.Highcharts !== 'undefined',
+                HighchartsChartFunction: typeof window.Highcharts?.chart === 'function',
+                existingScripts: document.querySelectorAll('script[src*="highcharts.js"]').length
+            });
+        }
+        
+        // Check if Highcharts is already loaded and available
+        if (typeof window.Highcharts !== 'undefined' && typeof window.Highcharts.chart === 'function') {
+            if (DEBUG) console.log('[Highcharts Loader] Highcharts already loaded, using existing');
+            // Small delay to ensure it's fully initialized
+            setTimeout(() => {
+                if (callback) callback();
+            }, 0);
+            return;
+        }
+        
+        // Check if script is already being loaded (avoid duplicate loads)
+        // Use a global flag to prevent race conditions
+        if (!window._highchartsLoading) {
+            window._highchartsLoading = {
+                callbacks: [],
+                script: null
+            };
+        }
+        
+        // If already loading, add callback to queue
+        if (window._highchartsLoading.script) {
+            if (DEBUG) console.log('[Highcharts Loader] Script already loading, queuing callback');
+            window._highchartsLoading.callbacks.push(callback);
+            return;
+        }
+        
+        // Check if script tag already exists (from previous attempt or external source)
+        const existingScript = document.querySelector('script[src*="highcharts.js"]');
+        if (existingScript) {
+            if (DEBUG) console.log('[Highcharts Loader] Script tag exists, waiting...');
+            window._highchartsLoading.script = existingScript;
+            window._highchartsLoading.callbacks.push(callback);
+            
+            // Wait for existing script to load
+            let checkCount = 0;
+            const maxChecks = 50; // 5 seconds max wait
+            const checkInterval = setInterval(() => {
+                checkCount++;
+                if (typeof window.Highcharts !== 'undefined' && typeof window.Highcharts.chart === 'function') {
+                    clearInterval(checkInterval);
+                    if (DEBUG) console.log('[Highcharts Loader] Existing script loaded successfully');
+                    // Execute all queued callbacks
+                    const callbacks = window._highchartsLoading.callbacks;
+                    window._highchartsLoading = null;
+                    callbacks.forEach(cb => {
+                        if (cb) setTimeout(() => cb(), 100);
+                    });
+                } else if (checkCount >= maxChecks) {
+                    clearInterval(checkInterval);
+                    console.warn('[Highcharts Loader] Highcharts failed to load after timeout', {
+                        checkCount,
+                        HighchartsExists: typeof window.Highcharts !== 'undefined',
+                        scriptComplete: existingScript.complete,
+                        scriptReadyState: existingScript.readyState
+                    });
+                    // Execute callbacks with error
+                    const callbacks = window._highchartsLoading.callbacks;
+                    window._highchartsLoading = null;
+                    callbacks.forEach(cb => {
+                        if (cb) cb(new Error('Highcharts failed to load'));
+                    });
+                }
+            }, 100);
+            return;
+        }
+        
+        // Load Highcharts script (new load)
+        if (DEBUG) console.log('[Highcharts Loader] Creating new script tag');
+        const script = document.createElement('script');
+        script.src = 'https://code.highcharts.com/highcharts.js';
+        script.async = true;
+        script.id = 'cbam-highcharts-loader'; // Add ID for easier debugging
+        
+        // Mark as loading and queue callback
+        window._highchartsLoading.script = script;
+        window._highchartsLoading.callbacks.push(callback);
+        
+        script.onload = () => {
+            if (DEBUG) console.log('[Highcharts Loader] Script onload fired');
+            // Verify Highcharts is actually loaded before calling callback
+            if (typeof window.Highcharts !== 'undefined' && typeof window.Highcharts.chart === 'function') {
+                if (DEBUG) console.log('[Highcharts Loader] Highcharts verified and ready');
+                // Execute all queued callbacks
+                const callbacks = window._highchartsLoading.callbacks;
+                window._highchartsLoading = null;
+                // Small delay to ensure Highcharts is fully initialized
+                callbacks.forEach(cb => {
+                    if (cb) setTimeout(() => cb(), 100);
+                });
+            } else {
+                console.error('[Highcharts Loader] Script loaded but Highcharts not available', {
+                    HighchartsExists: typeof window.Highcharts !== 'undefined',
+                    HighchartsType: typeof window.Highcharts,
+                    chartFunction: typeof window.Highcharts?.chart
+                });
+                // Execute callbacks with error
+                const callbacks = window._highchartsLoading.callbacks;
+                window._highchartsLoading = null;
+                callbacks.forEach(cb => {
+                    if (cb) cb(new Error('Highcharts failed to initialize'));
+                });
+            }
+        };
+        script.onerror = (error) => {
+            console.error('[Highcharts Loader] Script load error', error);
+            // Execute callbacks with error
+            const callbacks = window._highchartsLoading.callbacks;
+            window._highchartsLoading = null;
+            callbacks.forEach(cb => {
+                if (cb) cb(new Error('Failed to load Highcharts'));
+            });
+        };
+        document.head.appendChild(script);
+        if (DEBUG) console.log('[Highcharts Loader] Script tag appended to head');
+    }
             
         
 })


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/646
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/642


**Summary -** 

This PR fixes sporadic Highcharts error 16 seen by some users, restores the horizontal scroll for Annual Exposure Stat Cards, and suppresses a noisy Highcharts accessibility warning. Changes are visual or loader-only; no data or business logic is modified.

**Changes**

- Centralized Highcharts loader
  - Added cbam.utils.loadHighcharts in apps/cbam/cbam/public/js/web/utils.js
  - Prevents duplicate loads, handles race conditions, queues callbacks, and verifies initialization
  - Fallback path included for when the bundle isn’t loaded yet
- Updated dashboards to use centralized loader
  - financial_exposure_forecast.js
  - various_cost_comparisons/chart.js
  - ets_price_dashboard.js
  - Each page falls back to direct CDN load if utils aren’t ready
- Chart instance cleanup and resilience
  - Destroy existing chart instances before re-render to avoid conflicts
  - Better error handling and user-facing messages for render failures
- Suppressed Highcharts accessibility warning
  - Set accessibility: { enabled: false } on all chart configs
  - No functional impact; removes console noise
- Restored Annual Exposure Stat Cards horizontal scrolling
  - Switched cards row to flex-nowrap
  - Added overflow-x: auto and overflow-y: hidden for smooth horizontal scroll
  - Scoped to #annual-exposure-cards and parent .frappe-card

**Files Touched**

- apps/cbam/cbam/public/js/web/utils.js (new centralized loader)
- apps/cbam/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.js
  - Use centralized loader with fallback
  - Destroy existing charts before render
  - accessibility.enabled=false
  - Stat cards: flex-nowrap + horizontal scroll CSS
- apps/cbam/cbam/cbam/page/various_cost_comparisons/chart.js
  - Use centralized loader with fallback
  - accessibility.enabled=false
- apps/cbam/cbam/cbam/page/ets_price_dashboard/ets_price_dashboard.js
  - Use centralized loader with fallback
  - accessibility.enabled=false