### PR TITLE
gallehr/cbam#661: fixed daily send_missing_data_summary

### DIFF
--- a/cbam/cbam/page/various_cost_comparisons/missing_data_email.py
+++ b/cbam/cbam/page/various_cost_comparisons/missing_data_email.py
@@ -8,7 +8,8 @@ def send_missing_data_summary():
     filters = {}
     selected_filters = {"year": year}
     all_data = get_report_data(filters=filters, selected_filters=selected_filters, start=0, page_length=100000)["data"]
-    missing = [r for r in all_data if r.get('calculation_data_status') == "Missing"]
+    # Check if "Missing" is in the status string (handles HTML formatted status)
+    missing = [r for r in all_data if "Missing" in str(r.get('calculation_data_status', ''))]
     if not missing:
         return
     html = """


### PR DESCRIPTION
**## Problem**

The `send_missing_data_summary()` function was not detecting rows with "Missing" calculation data status, resulting in empty or incomplete email notifications to system managers.

**Root Cause:**

The `calculation_data_status` field contains HTML markup:
```python
'<span style="color:#d97a12;font-weight:600">Missing</span>'
```
But the comparison was checking for exact match with plain string `"Missing"`:
```python
missing = [r for r in all_data if r.get('calculation_data_status') == "Missing"]
```
This always returned an empty list because the HTML-wrapped value never matched the plain string.

**Solution**

Updated the comparison to use substring search instead of exact match:

```python
# Check if "Missing" is in the status string (handles HTML formatted status)
missing = [r for r in all_data if "Missing" in str(r.get('calculation_data_status', ''))]
```
---

**Files Modified**
- `apps/cbam/cbam/cbam/page/various_cost_comparisons/missing_data_email.py`
