### PR TITLE
gallehr/cbam#645: fixed attachment issue

### DIFF
--- a/cbam/cbam/doctype/cbam_emission_data/cbam_emission_data.py
+++ b/cbam/cbam/doctype/cbam_emission_data/cbam_emission_data.py
@@ -9,11 +9,19 @@ from cbam.utils import rename_any_file
 class CBAMEmissionData(Document):
 	def on_update(self):
 		self.update_good_installation_name()
-		if self.emission_attachment:
+		
+		# Check if emission_attachment has actually changed (new file uploaded)
+		has_attachment_changed = self.has_value_changed("emission_attachment")
+		
+		if self.emission_attachment and has_attachment_changed:
 			oc = self.operating_company or "OC-UNKNOWN"
 			emission_id = self.name or "EMISSION-UNKNOWN"
 			original_file = self.emission_attachment.split('/')[-1]
 			expected_prefix = f"{oc}_{emission_id}_"
+
+			# If file already starts with "OC", don't rename it - use as is
+			if original_file.upper().startswith("OC"):
+				return
 
 			# Only rename if current filename does not match target pattern exactly once
 			already_correct = original_file.startswith(expected_prefix)
@@ -65,6 +73,9 @@ class CBAMEmissionData(Document):
 				# Update the field value if file URL changed
 				if result["file_url"] != self.emission_attachment:
 					self.emission_attachment = result["file_url"]
+					# Update the database directly to persist the new filename
+					frappe.db.set_value(self.doctype, self.name, "emission_attachment", result["file_url"], update_modified=False)
+					frappe.db.commit()
 		
 	def after_insert(self):
 		self.add_to_installation_cht()

--- a/cbam/cbam/doctype/good/good.js
+++ b/cbam/cbam/doctype/good/good.js
@@ -67,6 +67,61 @@ frappe.ui.form.on("Good", {
             }
         }
 
+        // Add emission data attachment to sidebar
+        if (frm.doc.emission_data_attachment) {
+            let attachment_path = frm.doc.emission_data_attachment;
+            let file_name = attachment_path.split('/').pop();
+            
+            // Wait for sidebar to be ready
+            setTimeout(() => {
+                let sidebar_attachment = $(frm.sidebar.wrapper).find('.sidebar-attachments');
+                if (sidebar_attachment.length) {
+                    // Check if already added
+                    let existing_link = sidebar_attachment.find(`a[href="${attachment_path}"]`);
+                    if (existing_link.length === 0) {
+                        // Create attachment link
+                        let attachment_html = `
+                            <div class="attachment-row" style="padding: 8px; border-bottom: 1px solid #e0e0e0;">
+                                <a href="${attachment_path}" target="_blank" class="attachment-link" style="color: #2490ef; text-decoration: none;">
+                                    <i class="fa fa-file-o" style="margin-right: 5px;"></i>
+                                    ${file_name}
+                                </a>
+                                <div style="font-size: 11px; color: #757575; margin-top: 2px;">
+                                    Emission Data Attachment
+                                </div>
+                            </div>
+                        `;
+                        // Add to top of attachments list
+                        sidebar_attachment.prepend(attachment_html);
+                    }
+                } else {
+                    // If sidebar attachments section doesn't exist, create it
+                    let sidebar_content = $(frm.sidebar.wrapper).find('.sidebar-content');
+                    if (sidebar_content.length) {
+                        let attachment_section = `
+                            <div class="sidebar-section" style="margin-top: 10px;">
+                                <div class="section-head" style="padding: 8px; font-weight: 600; border-bottom: 1px solid #e0e0e0;">
+                                    ${__('Attachments')}
+                                </div>
+                                <div class="sidebar-attachments" style="max-height: 300px; overflow-y: auto;">
+                                    <div class="attachment-row" style="padding: 8px; border-bottom: 1px solid #e0e0e0;">
+                                        <a href="${attachment_path}" target="_blank" class="attachment-link" style="color: #2490ef; text-decoration: none;">
+                                            <i class="fa fa-file-o" style="margin-right: 5px;"></i>
+                                            ${file_name}
+                                        </a>
+                                        <div style="font-size: 11px; color: #757575; margin-top: 2px;">
+                                            Emission Data Attachment
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        `;
+                        sidebar_content.append(attachment_section);
+                    }
+                }
+            }, 500);
+        }
+
         // Don't show "Send Data Request" button for these statuses
         if(["Data Submitted", "Rejected"].includes(frm.doc.status)){
             return

--- a/cbam/cbam/doctype/good/good.py
+++ b/cbam/cbam/doctype/good/good.py
@@ -78,6 +78,11 @@ class Good(Document):
 		self.forward_to_employee = ""
 		self.manufacture = "I am able to provide the emission data of this product"
 		self.is_data_confirmed = False
+	
+	def on_update(self):
+		"""Called after document is saved to database"""
+		self.add_emission_attachment_to_sidebar()
+	
 	def on_trash(self):
 		self.delete_all_good_item()
 
@@ -188,6 +193,90 @@ class Good(Document):
 			customs_import.save()
 		else:
 			self.update_good_items()
+
+	def add_emission_attachment_to_sidebar(self):
+		"""Add/Update all files with same file_url from emission_data_attachment to sidebar"""
+		# Get old emission_data_attachment if document was updated
+		old_attachment = None
+		doc_before_save = self.get_doc_before_save()
+		if doc_before_save and self.has_value_changed("emission_data_attachment"):
+			old_attachment = doc_before_save.get("emission_data_attachment")
+		
+		# Get current emission_data_attachment
+		current_attachment = self.emission_data_attachment
+		
+		# Remove all old files with the old file_url if attachment changed
+		if old_attachment and old_attachment != current_attachment:
+			# Get all files attached to Good document with the old file_url
+			old_files = frappe.get_all("File", {
+				"file_url": old_attachment,
+				"attached_to_doctype": "Good",
+				"attached_to_name": self.name
+			}, ["name"])
+			
+			# Remove all old files
+			for old_file in old_files:
+				try:
+					frappe.delete_doc("File", old_file.name, ignore_permissions=True, force=True)
+				except Exception as e:
+					frappe.log_error(f"Error removing old emission attachment: {str(e)}", "Good.add_emission_attachment_to_sidebar")
+			
+			if old_files:
+				frappe.db.commit()
+		
+		# If no current attachment, return (old ones already removed above if they existed)
+		if not current_attachment:
+			return
+		
+		file_url = current_attachment
+		
+		# Get ALL files with this file_url (there can be multiple files with same URL but different filenames)
+		all_files_with_url = frappe.get_all("File", {
+			"file_url": file_url
+		}, ["name", "file_name", "is_private"], order_by="creation desc")
+		
+		if not all_files_with_url:
+			return
+		
+		# Get list of files already attached to this Good document with this file_url
+		existing_files = frappe.get_all("File", {
+			"file_url": file_url,
+			"attached_to_doctype": "Good",
+			"attached_to_name": self.name
+		}, ["file_name"])
+		
+		existing_file_names = {f.file_name for f in existing_files}
+		
+		# Attach all files with this file_url that are not already attached
+		for file_info in all_files_with_url:
+			file_name = file_info.file_name
+			
+			# Skip if this file is already attached
+			if file_name in existing_file_names:
+				continue
+			
+			# Determine if file is private
+			is_private = file_info.is_private if file_info.is_private is not None else (1 if file_url.startswith("/private/files/") else 0)
+			
+			# Create File record attached to this Good document
+			try:
+				new_file = frappe.get_doc({
+					"doctype": "File",
+					"file_name": file_name,
+					"file_url": file_url,
+					"attached_to_doctype": "Good",
+					"attached_to_name": self.name,
+					"is_private": is_private,
+					"folder": "Home/Attachments"
+				})
+				new_file.insert(ignore_permissions=True)
+			except frappe.DuplicateEntryError:
+				# File already exists, skip
+				pass
+			except Exception as e:
+				frappe.log_error(f"Error adding emission attachment to sidebar: {str(e)}", "Good.add_emission_attachment_to_sidebar")
+		
+		frappe.db.commit()
 
 	def update_good_items(self):
 		frappe.db.set_value("Good Item", {"good_number": self.name}, {

--- a/cbam/utils/__init__.py
+++ b/cbam/utils/__init__.py
@@ -50,6 +50,8 @@ def update_doc(doc):
     existing_doc.update(doc)
     existing_doc.save(ignore_permissions=True)
     _link_and_prefix_emission_attachment(doc, existing_doc)
+    # Reload to get any changes made in on_update hook (like renamed file attachments)
+    existing_doc.reload()
     return existing_doc
 
 @frappe.whitelist()

--- a/cbam/www/installation_list/index.js
+++ b/cbam/www/installation_list/index.js
@@ -410,7 +410,7 @@ function executeJS() {
                 {
                     label: __(""),
                     fieldname: "cb2",
-                    fieldtype: "Column Break",
+                    fieldtype: "Column Break", 
                 },
                 {
                     label: __("Upload Attachment"),


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/645
Parent: https://git.phamos.eu/gallehr/cbam/-/issues/596

Summary:

1. CBAM Emission Data file renaming

  - Renames only when a new file is uploaded (checks has_value_changed)
  - Skips renaming if the file already starts with "OC"
  - Persists renamed filename to the database to prevent "file not found" errors

2. Good doctype sidebar attachment sync

  - Automatically adds emission_data_attachment to the standard Frappe attachments sidebar
  - Syncs on document save/update
  - Removes old attachments when emission_data_attachment changes
  - Handles multiple files with the same file_url (attaches all matching files)