### PR TITLE
gallehr/cbam#664: Fix Good Rejection Status Update Issue

### DIFF
--- a/cbam/utils/goods.py
+++ b/cbam/utils/goods.py
@@ -56,11 +56,15 @@ def reject_goods(goods, reason=None):
             parent_operating_company = frappe.get_doc("Operating Company", _parent_operating_company)
             doc.supplier_name, doc.supplier_number = parent_operating_company.supplier_name , parent_operating_company.supplier_number
             doc.status = "Data Requested"
+            doc.save(ignore_permissions=True)
         else:    
             doc.supplier_name, doc.supplier_number = "", ""
             doc.rejection_reason = reason
             doc.status = "Rejected"
-        doc.save(ignore_permissions=True)
+            doc.save(ignore_permissions=True)
+            # Explicitly update status in database to ensure it persists
+            frappe.db.set_value("Good", g, "status", "Rejected", update_modified=False)
+        frappe.db.commit()  # Explicitly commit to ensure status is saved
         
         # Collect good information for email
         article_num = doc.article_number or doc.name or doc.cn_code or "N/A"


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/664
Parent: https://git.phamos.eu/gallehr/cbam/-/issues/660

**Summary**
Fixes an issue where the "Rejected" status was not updating in the desk view after rejecting goods. The status update now persists correctly in both local and production environments.

**Solution**
Added explicit database updates and commits to ensure the status change persists:
- Direct database update: Added frappe.db.set_value() to directly update the status in the database, bypassing any hooks or validations that might interfere
- Explicit commit: Added frappe.db.commit() to ensure the transaction is committed immediately after saving