### PR TITLE
Gallehr/cbam#664

### DIFF
--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -322,17 +322,20 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:doc.rejection_reason || doc.rejected_from_supplier",
    "fieldname": "rejection_details_section",
    "fieldtype": "Section Break",
    "label": "Rejection Details"
   },
   {
+   "depends_on": "eval:doc.rejection_reason || doc.rejected_from_supplier",
    "fieldname": "rejection_reason",
    "fieldtype": "Small Text",
    "label": "Rejection Reason",
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.rejection_reason || doc.rejected_from_supplier",
    "fieldname": "rejected_from_supplier",
    "fieldtype": "Link",
    "ignore_user_permissions": 1,

--- a/cbam/utils/goods.py
+++ b/cbam/utils/goods.py
@@ -54,9 +54,14 @@ def reject_goods(goods, reason=None):
         
         if _parent_operating_company: #if tier n+1 supplier
             parent_operating_company = frappe.get_doc("Operating Company", _parent_operating_company)
+            # Re-assign good to parent operating company
+            doc.operating_company = _parent_operating_company
             doc.supplier_name, doc.supplier_number = parent_operating_company.supplier_name , parent_operating_company.supplier_number
-            doc.status = "Data Requested"
+            # Set status to Rejected and keep rejection reason
+            doc.status = "Rejected"
             doc.save(ignore_permissions=True)
+            # Explicitly update status in database to ensure it persists
+            frappe.db.set_value("Good", g, "status", "Rejected", update_modified=False)
         else:    
             doc.supplier_name, doc.supplier_number = "", ""
             doc.rejection_reason = reason

--- a/cbam/www/goods_list/index.html
+++ b/cbam/www/goods_list/index.html
@@ -19,6 +19,7 @@
                     <option value="Data Requested">{{ _('Data Requested') }}</option>
                     <option value="Data Assigned">{{ _('Data Assigned') }}</option>
                     <option value="Data Submitted">{{ _('Data Submitted') }}</option>
+                    <option value="Rejected">{{ _('Rejected') }}</option>
                   </select>
 
                 </div>
@@ -184,6 +185,7 @@
                 {% elif doc.status == "Data Submitted" %}
                   {% set color = "green"%}
                 {% elif doc.status == "Rejected" %}
+                  {% set color = "red"%}
                   {% set mar_left_class= "m-left-sm" %}
                 {% endif %}
                 <div class="list-row-col list-subject level ">
@@ -347,6 +349,20 @@
                   <div class="tc-field-cont field-cont">
                       <span class="field-label">{{_('Specific (Indirect) Embedded Emissions [tCO2/t]')}}</span>
                       <div class="field tc-field">{{_(doc.specific_indirect_embedded_emissions) or ""}}</div>
+                  </div>
+              </div>
+              {% endif %}
+              {% if doc.rejection_reason or doc.rejected_from_supplier %}
+              <h2>{{_('Rejection Details')}}</h2>
+              <div class="container responsive-md" style="width: 100%">
+                  <div class="tc-field-cont field-cont">
+                      <span class="field-label">{{_('Rejected from Supplier')}}</span>
+                      <div class="field tc-field">{{_(doc.rejected_from_supplier) or ""}}</div>
+                  </div>
+                  
+                  <div class="tc-field-cont field-cont">
+                      <span class="field-label">{{_('Rejection Reason')}}</span>
+                      <div class="field tc-field" style="height: auto !important; white-space: pre-wrap; overflow-wrap: break-word;">{{_(doc.rejection_reason) or ""}}</div>
                   </div>
               </div>
               {% endif %}

--- a/cbam/www/goods_list/index.py
+++ b/cbam/www/goods_list/index.py
@@ -1,5 +1,6 @@
 import frappe
 from cbam.utils import get_roles, require_website_user
+from cbam.utils.supplier import get_supplier
 no_cache = 1
 
 
@@ -39,8 +40,12 @@ def get_user_roles(context, re_render=False):
 
 def get_goods_list(context, re_render=False):
     # Build filters for goods list
-    # Exclude Rejected status (rejected goods should disappear from supplier view)
-    filters = {"status": ["not in", ["Draft", "Rejected"]]}
+    # Filter by operating company and exclude only Draft status
+    # Include Rejected status so parent companies can see rejected goods reassigned to them
+    operating_company = get_supplier()
+    filters = {"status": ["!=", "Draft"]}
+    if operating_company:
+        filters["operating_company"] = operating_company
     goods_list = frappe.db.get_list("Good", filters=filters)
     
     if re_render:


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/664
Parent: https://git.phamos.eu/gallehr/cbam/-/issues/660

## Summary
Enhanced the good rejection functionality to support hierarchical operating company structures. When a child operating company rejects a good, it is now automatically reassigned to the parent operating company with proper rejection status and details visible in the parent's goods list.

## Changes

### 1. Enhanced Rejection Logic (`apps/cbam/cbam/utils/goods.py`)
- **Modified `reject_goods()` function** to handle parent operating companies:
  - When a good is rejected by a child operating company (with a parent), the good is automatically reassigned to the parent operating company
  - Status is set to "Rejected" (instead of "Data Requested")
  - Rejection reason and rejected_from_supplier fields are preserved
  - Supplier details are updated from the parent operating company
  - Existing behavior maintained for operating companies without parents

### 2. Goods List Filtering (`apps/cbam/cbam/www/goods_list/index.py`)
- **Updated `get_goods_list()` function**:
  - Removed "Rejected" status from exclusion list
  - Added filtering by operating company to ensure each company only sees their own goods
  - Rejected goods now appear in the parent company's goods list
  - Imported `get_supplier()` utility for operating company context

### 3. UI Enhancements (`apps/cbam/cbam/www/goods_list/index.html`)
- **Added "Rejected" status option** to the status filter dropdown
- **Added red color styling** for "Rejected" status badges
- **Created dedicated "Rejection Details" section**:
  - New section with `<h2>` heading matching "Emission Details" style
  - Displays "Rejected from Supplier" and "Rejection Reason" fields
  - Positioned below "Emission Details" section
  - Only visible when rejection data exists

### 4. Doctype Configuration (`apps/cbam/cbam/cbam/doctype/good/good.json`)
- **Added conditional visibility** to rejection details:
  - Added `depends_on` condition to `rejection_details_section` to show only when rejection data exists
  - Added `depends_on` conditions to `rejection_reason` and `rejected_from_supplier` fields
