### PR TITLE
Gallehr/cbam#674: CN Code Hierarchical Grouping with Fallback Logic

### DIFF
--- a/cbam/cbam/doctype/cn_code/cn_code.js
+++ b/cbam/cbam/doctype/cn_code/cn_code.js
@@ -1,8 +1,37 @@
 // Copyright (c) 2025, phamos GmbH and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("CN Code", {
-// 	refresh(frm) {
+frappe.ui.form.on("CN Code", {
+	cn_code(frm) {
+		// Auto-set is_group based on CN code length
+		if (frm.doc.cn_code) {
+			const cn_code_str = String(frm.doc.cn_code);
+			const cn_code_len = cn_code_str.length;
 
-// 	},
-// });
+			if (cn_code_len === 8) {
+				// 8-digit codes cannot be groups
+				frm.set_value("is_group", 0);
+				frm.set_df_property("is_group", "read_only", 1);
+			} else if (cn_code_len === 4 || cn_code_len === 6) {
+				// 4 and 6-digit codes must be groups
+				frm.set_value("is_group", 1);
+				frm.set_df_property("is_group", "read_only", 1);
+			} else {
+				// Invalid length - allow editing
+				frm.set_df_property("is_group", "read_only", 0);
+			}
+		}
+	},
+
+	refresh(frm) {
+		// Set read-only state based on CN code length
+		if (frm.doc.cn_code) {
+			const cn_code_str = String(frm.doc.cn_code);
+			const cn_code_len = cn_code_str.length;
+
+			if (cn_code_len === 8 || cn_code_len === 4 || cn_code_len === 6) {
+				frm.set_df_property("is_group", "read_only", 1);
+			}
+		}
+	}
+});

--- a/cbam/cbam/doctype/cn_code/cn_code.json
+++ b/cbam/cbam/doctype/cn_code/cn_code.json
@@ -7,7 +7,9 @@
  "engine": "InnoDB",
  "field_order": [
   "cn_code",
-  "column_break_dkpq"
+  "parent_cn_code",
+  "column_break_dkpq",
+  "is_group"
  ],
  "fields": [
   {
@@ -21,18 +23,35 @@
    "unique": 1
   },
   {
+   "fieldname": "parent_cn_code",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "in_list_view": 1,
+   "label": "Parent CN Code",
+   "options": "CN Code"
+  },
+  {
    "fieldname": "column_break_dkpq",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_group",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Group"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
+ "is_tree": 1,
  "links": [],
  "modified": "2025-06-27 12:13:14.982194",
  "modified_by": "Administrator",
  "module": "CBAM",
  "name": "CN Code",
  "naming_rule": "By fieldname",
+ "nsm_parent_field": "parent_cn_code",
  "owner": "Administrator",
  "permissions": [
   {

--- a/cbam/cbam/doctype/cn_code/cn_code.py
+++ b/cbam/cbam/doctype/cn_code/cn_code.py
@@ -7,8 +7,51 @@ from frappe import _
 
 class CNCode(Document):
 	def validate(self):
-		if self.cn_code and len(str(self.cn_code)) > 8:
-			frappe.throw(_("CN Code must be exactly 8 digits"))
+		cn_code_str = str(self.cn_code) if self.cn_code else ""
+		cn_code_len = len(cn_code_str)
 
+		# Validate length (must be 4, 6, or 8 digits)
+		if cn_code_len not in [4, 6, 8]:
+			frappe.throw(_("CN Code must be 4, 6, or 8 digits"))
 
- 
+		# Force is_group based on length (mandatory rule)
+		if cn_code_len == 8:
+			# 8-digit codes are always leaf nodes (not groups)
+			if self.is_group:
+				frappe.throw(_("8-digit CN Codes cannot be groups. Only 4-digit and 6-digit codes can be groups."))
+			self.is_group = 0
+		elif cn_code_len in [4, 6]:
+			# 4 and 6-digit codes must be groups
+			if not self.is_group:
+				frappe.throw(_("{0}-digit CN Codes must be groups. Please check 'Is Group'.").format(cn_code_len))
+			self.is_group = 1
+
+		# Validate parent relationship
+		if self.parent_cn_code:
+			parent_doc = frappe.get_doc("CN Code", self.parent_cn_code)
+			parent_code_str = str(parent_doc.cn_code)
+			parent_code_len = len(parent_code_str)
+
+			# Parent must be a group
+			if not parent_doc.is_group:
+				frappe.throw(_("Parent CN Code must be a group (is_group must be checked)"))
+
+			# Parent must be shorter than child
+			if parent_code_len >= cn_code_len:
+				frappe.throw(_("Parent CN Code must be shorter than child CN Code"))
+
+			# Parent must be a prefix of child
+			if not cn_code_str.startswith(parent_code_str):
+				frappe.throw(_("Parent CN Code '{0}' must be a prefix of child CN Code '{1}'").format(
+					parent_code_str, cn_code_str
+				))
+
+			# Validate hierarchy: 4-digit → 6-digit → 8-digit
+			if cn_code_len == 6 and parent_code_len != 4:
+				frappe.throw(_("6-digit CN Code must have a 4-digit parent"))
+			elif cn_code_len == 8 and parent_code_len != 6:
+				frappe.throw(_("8-digit CN Code must have a 6-digit parent"))
+
+		# Validate: 8-digit codes cannot have children (they are leaf nodes)
+		if cn_code_len == 8 and self.is_group:
+			frappe.throw(_("8-digit CN Codes cannot be groups. Only 4-digit and 6-digit codes can be groups."))

--- a/cbam/cbam/doctype/operating_company/operating_company.py
+++ b/cbam/cbam/doctype/operating_company/operating_company.py
@@ -5,22 +5,22 @@ import frappe
 import json
 from frappe.model.document import Document
 
-MISSING_CONTACT_MESSAGE = """The contact email provided already exists for another Operating Company. 
+MISSING_CONTACT_MESSAGE = """The contact email provided already exists for another Operating Company.
 		The System Manager will look into it and get back to you. Please wait before using this Supplier."""
 
 class OperatingCompany(Document):
-	
+
 	def check_user_exists(self, user):
 		cc_filters = {
-			"commercial_contact_user": user, 
+			"commercial_contact_user": user,
 			"name": ["!=", self.name]
 		}
 		cr_filters = {
-			"cbam_representative_user": user, 
+			"cbam_representative_user": user,
 			"name": ["!=", self.name]
 		}
-		
-		if (not frappe.db.exists("Operating Company", cc_filters) 
+
+		if (not frappe.db.exists("Operating Company", cc_filters)
 	  		and not frappe.db.exists("Operating Company", cr_filters)):
 			return True
 		return False
@@ -32,7 +32,7 @@ class OperatingCompany(Document):
 		if self.main_contact_employee_email:
 			if self.check_user_exists(self.main_contact_employee_email):
 				self.create_commercial_contact()
-				self.status = "Pending Verification"		
+				self.status = "Pending Verification"
 			else:
 				frappe.msgprint(MISSING_CONTACT_MESSAGE)
 				# Only send email once
@@ -51,13 +51,13 @@ class OperatingCompany(Document):
 		self.validate_conflict()
 
 
-	
+
 
 
 	def validate_cr_user(self):
-		if self.cbam_representive_employee_email:	
+		if self.cbam_representive_employee_email:
 			if self.check_user_exists(self.cbam_representive_employee_email):
-				
+
 				self.create_cbam_user()
 				self.status = "Pending Verification"
 			else:
@@ -73,9 +73,9 @@ class OperatingCompany(Document):
 
 
 	def validate_conflict(self):
-	
+
 		if self.status in [
-			"CBAM Rep User Conflict", 
+			"CBAM Rep User Conflict",
 			"Missing Commercial Contact"
 		]:
 			self.user_conflict = 1
@@ -100,12 +100,12 @@ class OperatingCompany(Document):
 				user.last_name = self.main_contact_employee_last_name if (
 					self.main_contact_employee_first_name) else ""
 				user.email = self.main_contact_employee_email
-				
+
 				user.append("roles",{
 					"role": frappe.db.get_single_value("CBAM Settings", "commercial_contact_user_role")
 				})
 				user.save(ignore_permissions=True)
-				
+
 				username = user.name
 
 
@@ -120,8 +120,8 @@ class OperatingCompany(Document):
 		user = None
 		if self.cbam_representive_employee_email == self.commercial_contact_user:
 			user = frappe.get_doc("User", self.commercial_contact_user)
-		
-			
+
+
 		elif frappe.db.exists("User", self.cbam_representive_employee_email):
 			existing_username = frappe.db.get_value("User", self.cbam_representive_employee_email, "name")
 			user = frappe.get_doc("User", existing_username)
@@ -141,7 +141,7 @@ class OperatingCompany(Document):
 				"role": frappe.db.get_single_value("CBAM Settings", "cbam_representative_user_role")
 			})
 			user.save(ignore_permissions=True)
-					
+
 			self.cbam_representative_user = user.name
 			self.create_permissions(user.name)
 
@@ -163,7 +163,7 @@ class OperatingCompany(Document):
 	def send_signup_request(self):
 		email = frappe.get_doc("Notification", frappe.db.get_single_value("CBAM Settings", "signup_template"))
 		email.send(self)
-		
+
 		self.status = "Pending Verification"
 		self.save(ignore_permissions=True)
 
@@ -190,7 +190,7 @@ class OperatingCompany(Document):
 			return
 		if not frappe.db.exists("User Permission", {"user": user, "allow":"Operating Company"}):
 			us_pem = frappe.new_doc("User Permission")
-			us_pem.user = user 
+			us_pem.user = user
 			us_pem.allow = "Operating Company"
 			us_pem.for_value = self.name
 			us_pem.is_default = 1
@@ -206,6 +206,7 @@ class OperatingCompany(Document):
 
 	@frappe.whitelist()
 	def update_contact(self, values):
+		frappe.log_error("update_contact", values)
 		values = frappe._dict(values)
 		old_user = ''
 		if values.type == "Commercial Contact":
@@ -227,7 +228,7 @@ class OperatingCompany(Document):
 			self.cbam_representive_employee_position = values.position
 			self.cbam_representive_employee_email = values.email
 			old_user = self.cbam_representative_user
-		
+
 		if not self.is_new():
 			self.save()
 
@@ -279,7 +280,7 @@ def send_bulk_signup_request(operating_companys):
 
 def update_goods_on_operating_company_change(doc, method):
     # Fetch all Goods records linked to this Operating Company and not "Data Submitted"
-    goods_list = frappe.get_all("Good", 
+    goods_list = frappe.get_all("Good",
         filters={
             "operating_company": doc.name,
             "status": ["!=", "Data Submitted"]

--- a/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py
+++ b/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py
@@ -19,13 +19,13 @@ def get_quarter_from_dates(from_date, to_date):
     """Get quarter number from from_date and to_date"""
     if not from_date or not to_date:
         return None
-    
+
     # Convert to datetime if string
     if isinstance(from_date, str):
         from_date = datetime.strptime(from_date, '%Y-%m-%d')
     if isinstance(to_date, str):
         to_date = datetime.strptime(to_date, '%Y-%m-%d')
-    
+
     # Determine quarter based on to_date
     month = to_date.month
     if month <= 3:
@@ -75,7 +75,7 @@ def fetch_cbam_report_rows(cbam_reports, from_year, to_year):
                 quarter_year = parent.to_date.year
         else:
             quarter_year = report_year
-        
+
         if quarter and quarter_year:
             uploaded_quarters.add((quarter_year, quarter))
             years_with_reports.add(quarter_year)
@@ -101,10 +101,10 @@ def fetch_cbam_report_rows(cbam_reports, from_year, to_year):
                     year = int(latest_ets.price_year)
                     # Use quarter_year for filtering instead of ETS price year to get actual report data
                     report_year = quarter_year
-                  
+
                     if (from_year and report_year < from_year) or (to_year and report_year > to_year):
                         continue
-    
+
                     ets_price = extract_numeric_value(latest_ets.price)
                 else:
                     continue
@@ -125,7 +125,7 @@ def fetch_cbam_report_rows(cbam_reports, from_year, to_year):
                     continue
 
                 cbam_factor = extract_numeric_value(cbam_factor)
-                
+
                 # Get benchmark from External Good (stored value)
                 # Fallback to 0.0 if not calculated
                 bench_mark = extract_numeric_value(getattr(eg, "country_specific_default_cbam_benchmark", None) or 0.0)
@@ -134,11 +134,10 @@ def fetch_cbam_report_rows(cbam_reports, from_year, to_year):
                 sev_key = (report_year, installation_country, cn_code)
 
                 if sev_key not in standard_emission_value_cache:
-                    standard_emission_value_cache[sev_key] = frappe.db.get_value(
-                        "Standard Emission Value",
-                        {"year": report_year, "country": installation_country, "cn_code": cn_code},
-                        "emission_value"
-                    ) or 0.0
+                    # Use fallback function to get SEV with parent CN code groups
+                    from cbam.utils.benchmark import get_standard_emission_value
+                    sev_value = get_standard_emission_value(cn_code, installation_country, report_year)
+                    standard_emission_value_cache[sev_key] = sev_value or 0.0
 
                 standard_emission_value = extract_numeric_value(standard_emission_value_cache[sev_key])
 
@@ -150,7 +149,7 @@ def fetch_cbam_report_rows(cbam_reports, from_year, to_year):
                     )
                 except Exception:
                     real_emission_cost = 0.0
-                    
+
                 try:
                     standard_emission_cost = (
                         (standard_emission_value - (bench_mark * cbam_factor)
@@ -228,14 +227,11 @@ def duplicate_future_year_rows(base_rows, future_years):
             # Round to 4 decimal places (German calculation standard)
             bench_mark = round(extract_numeric_value(bench_mark), 4)
             future_row["bench_mark_emission_value"] = bench_mark
-            # SEV
-            sev = frappe.db.get_value(
-                "Standard Emission Value",
-                {"year": future_year, "country": installation_country, "cn_code": cn_code},
-                "emission_value"
-            ) or 0.0
+            # SEV with fallback to parent CN code groups
+            from cbam.utils.benchmark import get_standard_emission_value
+            sev = get_standard_emission_value(cn_code, installation_country, future_year) or 0.0
             future_row["standard_emission_value"] = extract_numeric_value(sev)
-            
+
             # Recalculate costs
             try:
                 standard_emission_cost = (
@@ -258,7 +254,7 @@ def duplicate_future_year_rows(base_rows, future_years):
 
 def aggregate_year_totals(data, uploaded_quarters):
     year_totals = defaultdict(lambda: {"actual": 0, "standard": 0, "is_forecast": False})
-    
+
     # Aggregate data by YEAR using the new fields in all_rows
     for row in data:
         year = row.get("year")
@@ -266,7 +262,7 @@ def aggregate_year_totals(data, uploaded_quarters):
             # Sum all items for each year to get total CBAM cost for that year
             year_totals[year]["actual"] += row.get("real_emission_cost", 0) or 0
             year_totals[year]["standard"] += row.get("standard_emission_cost", 0) or 0
-    
+
     # Mark years as actual data if they have uploaded quarters, others as forecast
     for year in year_totals:
         has_uploaded_quarters = any((year, q) in uploaded_quarters for q in range(1, 5))
@@ -292,7 +288,7 @@ def build_chart_data(data, year_totals, current_year, uploaded_quarters, year_du
 
     # Build a set of all years (selected year + future) and all quarters
     all_years = sorted(set(row.get('year') for row in base_rows + future_rows if row.get('year')))
-    
+
     # Ensure we show the selected year and ALL years after it (including gaps)
     # This ensures 2024, 2025, 2026, 2027 are all shown when 2024 is selected
     if base_year not in all_years:
@@ -300,16 +296,16 @@ def build_chart_data(data, year_totals, current_year, uploaded_quarters, year_du
     else:
         # Include the selected year and all years after it, even if there are gaps
         all_years = [y for y in all_years if y >= base_year]
-    
+
     # Also include any missing years between base_year and max_future_year
     max_year_in_data = max(all_years) if all_years else base_year
     for year in range(base_year + 1, max_year_in_data + 1):
         if year not in all_years:
             all_years.append(year)
-    
+
     # Sort again to maintain order
     all_years = sorted(all_years)
-    
+
     for year in all_years:
         for quarter in range(1, 5):
             last_month = {1: 3, 2: 6, 3: 9, 4: 12}[quarter]
@@ -358,9 +354,9 @@ def build_chart_data(data, year_totals, current_year, uploaded_quarters, year_du
                 quarter_rows = [r for r in future_rows if r.get('year') == year and r.get('quarter') == quarter]
                 quarter_sum = sum(r.get('standard_emission_cost', 0) or 0 for r in quarter_rows)
                 actual_data.append(None)
-                
+
                 # Debug logging removed to prevent BrokenPipeError
-                
+
                 if quarter_rows and quarter_sum != 0:
                     # Q1 and Q2: use sum of all duplicated row values
                     forecast_data.append(quarter_sum)
@@ -418,7 +414,7 @@ def get_cbam_report_data(cbam_reports=None, start=0, page_length=50, year=None, 
     except Exception as e:
         frappe.log_error("Error parsing parameters in get_cbam_report_data", str(e))
         return {"columns": [], "data": [], "chart_data": {}, "total_count": 0, "error": str(e)}
-    
+
     try:
         # Support both 'year' and 'from_year' parameters for backward compatibility
         if year is not None:
@@ -427,15 +423,15 @@ def get_cbam_report_data(cbam_reports=None, start=0, page_length=50, year=None, 
             from_year = int(from_year)
         else:
             from_year = None
-            
+
         to_year = int(to_year) if to_year else None
         columns = get_columns()
-        
+
         base_rows, uploaded_quarters, years_with_reports, year_due_dates = fetch_cbam_report_rows(cbam_reports, from_year, to_year)
     except Exception as e:
         frappe.log_error("Error in get_cbam_report_data processing", str(e))
         return {"columns": [], "data": [], "chart_data": {}, "total_count": 0, "error": str(e)}
-    
+
     try:
         # Determine future years (e.g., from ETS Carbon Price)
         # This part of the logic needs to be re-evaluated to correctly identify future years
@@ -455,9 +451,9 @@ def get_cbam_report_data(cbam_reports=None, start=0, page_length=50, year=None, 
 
         future_years = [year for year in range(current_year + 1, max_future_year + 1) if year not in years_with_reports]
         future_rows = duplicate_future_year_rows(base_rows, future_years)
-        
+
         all_data = base_rows + future_rows  # Keep full data for chart
-        
+
         # Initialize cbam_factor_cache
         cbam_factor_cache = {}
         for year in years_with_reports:
@@ -469,7 +465,7 @@ def get_cbam_report_data(cbam_reports=None, start=0, page_length=50, year=None, 
                     limit=1
                 )
                 cbam_factor_cache[year] = cbam_factor_doc[0].cbam_factor if cbam_factor_doc else None
-        
+
         # Determine base_year - if no year selected, use the earliest year with data
         if from_year:
             base_year = int(from_year)
@@ -485,7 +481,7 @@ def get_cbam_report_data(cbam_reports=None, start=0, page_length=50, year=None, 
 
         # Calculate year totals from full data
         year_totals = aggregate_year_totals(all_data, uploaded_quarters)
-        
+
         # For chart_data, treat selected year as current year and all greater years as future
         chart_data = build_chart_data(all_data, year_totals, base_year, uploaded_quarters, year_due_dates, cbam_factor_cache, max_future_year, base_rows=[row for row in all_data if row.get('year') == base_year], future_rows=[row for row in all_data if row.get('year') > base_year])
 
@@ -493,13 +489,13 @@ def get_cbam_report_data(cbam_reports=None, start=0, page_length=50, year=None, 
     except Exception as e:
         frappe.log_error("get_cbam_report_data main processing", str(e))
         return {"columns": [], "data": [], "chart_data": {}, "total_count": 0, "error": str(e)}
-    
+
 @frappe.whitelist()
 def get_available_years():
     """Get available years from CBAM report from_date and to_date"""
     user = frappe.session.user
     current_year = datetime.now().year
-    
+
     # Check if user is a System Manager
     user_roles = frappe.get_roles(user)
     is_system_manager = 'System Manager' in user_roles
@@ -517,7 +513,7 @@ def get_available_years():
         fields=["from_date", "to_date"],
         order_by="creation desc"
     )
-    
+
     available_years = set()
     for report in reports:
         # Try to get year from from_date first, then to_date
@@ -530,7 +526,7 @@ def get_available_years():
                     year = report["from_date"].year
             except:
                 pass
-        
+
         if not year and report.get("to_date"):
             try:
                 if isinstance(report["to_date"], str):
@@ -539,10 +535,10 @@ def get_available_years():
                     year = report["to_date"].year
             except:
                 pass
-        
+
         if year and year <= current_year:  # Only include past and current years
             available_years.add(year)
-    
+
     # Return sorted list of available years (descending order)
     return sorted(list(available_years), reverse=True)
 
@@ -550,13 +546,13 @@ def get_available_years():
 def get_cbam_reports_by_year(year):
     """Get CBAM reports for a specific year based on from_date and to_date"""
     user = frappe.session.user
-    
+
     # Filter by user permissions if not System Manager
     user_roles = frappe.get_roles(user)
     is_system_manager = 'System Manager' in user_roles
-    
+
     filters = {}
-    
+
     # Only filter by Declarant if user has explicit restrictions (not all non-managers)
     if not is_system_manager:
         # Check if user has limited scope
@@ -564,7 +560,7 @@ def get_cbam_reports_by_year(year):
         if declarant:
             filters["declarant"] = declarant
     # System Managers and users with broader access see all reports
-    
+
     # Add year filter using from_date and to_date
     year = int(year)
     filters["from_date"] = [">=", f"{year}-01-01"]
@@ -609,7 +605,7 @@ def extend_year_due_dates_with_future_years(year_due_dates, base_year):
 
         if ets_years:
             ets_years.add(max(ets_years) + 1)
-            
+
         # Only add years greater than base_year
         for year in ets_years:
             if year > base_year:
@@ -622,13 +618,13 @@ def extend_year_due_dates_with_future_years(year_due_dates, base_year):
                         fields=["due_date"],
                         limit=1
                     )
-                    
+
                     if custom_imports and custom_imports[0].due_date:
                         year_due_dates[year_str] = custom_imports[0].due_date
                     else:
                         # Fallback to default due date
                         year_due_dates[year_str] = f"{year}-01-31"
-        
+
         return year_due_dates
     except Exception as e:
         frappe.log_error("extend_year_due_dates_with_future_years", str(e))

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.py
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.py
@@ -49,7 +49,7 @@ def get_columns():
 			"fieldname": "cn_code",
 			"fieldtype": "Data",
 			"label": "CN Code",
-			"width": 150	
+			"width": 150
 		},
 		{
 			"fieldname": "article_number",
@@ -124,7 +124,7 @@ def get_columns():
             "label": "ETS Carbon Price",
         }
 	]
-             
+
     return columns
 
 def get_data(filters=None):
@@ -161,7 +161,7 @@ def get_data(filters=None):
         article_number_list = ', '.join(f"'{s}'" for s in filters["article_number"])
         where_clauses.append(f"(g.article_number IN ({article_number_list}))")
         where_clauses_eg.append(f"(eg.article_no IN ({article_number_list}))")
-    
+
     # Reporting Period filter
     if filters.get("reporting_period"):
         reporting_period_list = ', '.join(f"'{s}'" for s in filters["reporting_period"])
@@ -172,13 +172,13 @@ def get_data(filters=None):
     where_sql = ""
     if where_clauses:
         where_sql = "WHERE " + " AND ".join(where_clauses)
-        
+
     where_sql_eg = ""
     if where_clauses_eg:
         where_sql_eg = "WHERE " + " AND ".join(where_clauses_eg) if where_clauses_eg else ""
-        
+
     data = frappe.db.sql(f"""
-        SELECT 
+        SELECT
             eg.cn_code,
             eg.article_no AS article_number,
             eg.supplier,
@@ -199,14 +199,14 @@ def get_data(filters=None):
             ) * IFNULL(eg.raw_mass, 0) * {ets_carbon_price}) AS real_emission_cost,
 
             ((
-                IFNULL(e.emission_value, 0.0) 
+                IFNULL(e.emission_value, 0.0)
                 - (COALESCE(eg.country_specific_default_cbam_benchmark, 0.0) * IFNULL(cbam.cbam_factor, 0.0))
                 - ((IFNULL(e.emission_value, 0.0) * IFNULL(eg.carbon_price_due, 0.0)) / {ets_carbon_price})
-            ) 
+            )
             * IFNULL(eg.raw_mass, 0.0) * {ets_carbon_price}) AS standard_emission_cost
 
         FROM `tabExternal Good` eg
-        LEFT JOIN `tabStandard Emission Value` e 
+        LEFT JOIN `tabStandard Emission Value` e
             ON eg.cn_code = e.cn_code AND eg.installation_country = e.country
 
         LEFT JOIN `tabReporting Period` rp
@@ -216,14 +216,14 @@ def get_data(filters=None):
             ON cbam.name = rp.parent
 
 		{where_sql_eg}
-        
+
         UNION
 
-        SELECT 
+        SELECT
             g.cn_code,
             g.article_number,
             g.supplier_name AS supplier,
-            g.installation_country,	
+            g.installation_country,
             IFNULL(g.raw_mass,0.0) AS raw_mass,
             IFNULL(g.mass_per_article,0.0) AS mass_per_article,
             IFNULL(g.buying_price,0.0) AS buying_price,
@@ -248,10 +248,10 @@ def get_data(filters=None):
 
         FROM `tabGood` g
 
-        LEFT JOIN `tabStandard Emission Value` e 
+        LEFT JOIN `tabStandard Emission Value` e
             ON g.cn_code = e.cn_code AND g.installation_country = e.country
- 
-        LEFT JOIN `tabReporting Period` rp 
+
+        LEFT JOIN `tabReporting Period` rp
             ON rp.reporting_period = g.internal_customs_import_number AND rp.parent IS NOT NULL
         LEFT JOIN `tabCBAM Factor` cbam
             ON cbam.name = rp.parent AND rp.parenttype = 'CBAM Factor'
@@ -261,6 +261,9 @@ def get_data(filters=None):
 
     unique_keys = set()
     final_data = []
+
+    # Import SEV fallback function
+    from cbam.utils.benchmark import get_standard_emission_value
 
     for row in data:
         key = (
@@ -273,6 +276,43 @@ def get_data(filters=None):
                 # Round benchmark value to 4 decimal places (German calculation standard)
                 if row.get("bench_mark") is not None:
                     row["bench_mark"] = round(float(row["bench_mark"]), 4)
+
+                # Apply SEV fallback if standard_emission_value is 0 or None
+                if not row.get("standard_emission_value") or row.get("standard_emission_value") == 0.0:
+                    # Get year from reporting_period if available, otherwise use current year
+                    year = None
+                    if row.get("reporting_period"):
+                        # Try to extract year from reporting period
+                        try:
+                            year_doc = frappe.db.get_value("Reporting Period", row["reporting_period"], "year")
+                            if year_doc:
+                                year = frappe.db.get_value("Year", year_doc, "year")
+                        except:
+                            pass
+
+                    if not year:
+                        from datetime import datetime
+                        year = datetime.now().year
+
+                    # Try to get SEV with fallback to parent CN code groups
+                    cn_code = row.get("cn_code")
+                    country = row.get("installation_country")
+                    if cn_code and country:
+                        sev_value = get_standard_emission_value(cn_code, country, year)
+                        if sev_value:
+                            row["standard_emission_value"] = sev_value
+                            # Recalculate standard_emission_cost with new SEV value
+                            if row.get("bench_mark") and row.get("cbam_factor") and row.get("raw_mass"):
+                                try:
+                                    standard_emission_cost = (
+                                        (sev_value - (row["bench_mark"] * row["cbam_factor"])
+                                        - ((sev_value * row.get("carbon_price_due", 0.0)) / ets_carbon_price if ets_carbon_price else 0))
+                                        * row["raw_mass"] * ets_carbon_price
+                                    )
+                                    row["standard_emission_cost"] = standard_emission_cost
+                                except:
+                                    pass
+
                 final_data.append(row)
                 unique_keys.add(key)
 

--- a/cbam/patches.txt
+++ b/cbam/patches.txt
@@ -1,6 +1,6 @@
 [pre_model_sync]
 # Patches added in this section will be executed before doctypes are migrated
-# Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations 
+# Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
 
 cbam.patches.v15_4_3.setup_cbam_rep_name
 
@@ -18,3 +18,4 @@ cbam.patches.v15_4_3.remove_old_pages
 cbam.patches.v15_4_3.add_system_manager_role_to_workspaces
 cbam.patches.v15_4_3.update_customs_import_year
 cbam.patches.v15_4_3.update_declarant_user_permissions
+cbam.patches.v15_4_4.add_cn_code_tree_structure

--- a/cbam/patches/v15_4_4/add_cn_code_tree_structure.py
+++ b/cbam/patches/v15_4_4/add_cn_code_tree_structure.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2025, phamos GmbH and contributors
+# For license information, please see license.txt
+
+import frappe
+
+def execute():
+	"""
+	Migrate existing CN codes to tree structure.
+	For each 8-digit CN code, creates parent 6-digit and 4-digit groups if they don't exist.
+	"""
+
+	# Get all existing CN codes
+	all_cn_codes = frappe.get_all("CN Code", fields=["name", "cn_code"], order_by="cn_code")
+
+	if not all_cn_codes:
+		frappe.msgprint("No CN codes found to migrate")
+		return
+
+	created_4digit = 0
+	created_6digit = 0
+	updated_8digit = 0
+	errors = []
+
+	# Process each CN code
+	for cn_code_doc in all_cn_codes:
+		try:
+			cn_code_str = str(cn_code_doc.cn_code)
+			cn_code_len = len(cn_code_str)
+
+			# Only process 8-digit codes for migration
+			if cn_code_len != 8:
+				continue
+
+			# Extract parent codes
+			six_digit_code = int(cn_code_str[:6])
+			four_digit_code = int(cn_code_str[:4])
+
+			# Step 1: Create or get 4-digit parent (if needed)
+			four_digit_name = frappe.db.get_value("CN Code", {"cn_code": four_digit_code}, "name")
+			if not four_digit_name:
+				# Create 4-digit group
+				four_digit_doc = frappe.new_doc("CN Code")
+				four_digit_doc.cn_code = four_digit_code
+				four_digit_doc.is_group = 1
+				four_digit_doc.parent_cn_code = None  # Root level
+				four_digit_doc.save(ignore_permissions=True)
+				four_digit_name = four_digit_doc.name
+				created_4digit += 1
+				frappe.db.commit()
+			else:
+				# Ensure existing 4-digit is marked as group
+				existing_is_group = frappe.db.get_value("CN Code", four_digit_name, "is_group")
+				if not existing_is_group:
+					frappe.db.set_value("CN Code", four_digit_name, "is_group", 1, update_modified=False)
+
+			# Step 2: Create or get 6-digit parent (if needed)
+			six_digit_name = frappe.db.get_value("CN Code", {"cn_code": six_digit_code}, "name")
+			if not six_digit_name:
+				# Create 6-digit group
+				six_digit_doc = frappe.new_doc("CN Code")
+				six_digit_doc.cn_code = six_digit_code
+				six_digit_doc.is_group = 1
+				six_digit_doc.parent_cn_code = four_digit_name
+				six_digit_doc.save(ignore_permissions=True)
+				six_digit_name = six_digit_doc.name
+				created_6digit += 1
+				frappe.db.commit()
+			else:
+				# Ensure existing 6-digit is marked as group and has correct parent
+				existing_is_group = frappe.db.get_value("CN Code", six_digit_name, "is_group")
+				existing_parent = frappe.db.get_value("CN Code", six_digit_name, "parent_cn_code")
+
+				if not existing_is_group:
+					frappe.db.set_value("CN Code", six_digit_name, "is_group", 1, update_modified=False)
+
+				if existing_parent != four_digit_name:
+					frappe.db.set_value("CN Code", six_digit_name, "parent_cn_code", four_digit_name, update_modified=False)
+
+			# Step 3: Update 8-digit code to have 6-digit as parent
+			current_parent = frappe.db.get_value("CN Code", cn_code_doc.name, "parent_cn_code")
+			current_is_group = frappe.db.get_value("CN Code", cn_code_doc.name, "is_group")
+
+			if current_parent != six_digit_name:
+				frappe.db.set_value("CN Code", cn_code_doc.name, "parent_cn_code", six_digit_name, update_modified=False)
+				updated_8digit += 1
+
+			if current_is_group:
+				frappe.db.set_value("CN Code", cn_code_doc.name, "is_group", 0, update_modified=False)
+
+			frappe.db.commit()
+
+		except Exception as e:
+			error_msg = f"Error processing CN Code {cn_code_doc.name}: {str(e)}"
+			errors.append(error_msg)
+			frappe.log_error(error_msg, "CN Code Tree Migration Error")
+			continue
+
+	# Final commit
+	frappe.db.commit()
+
+	# Report results
+	message = f"""
+	CN Code Tree Migration Complete:
+	- Created {created_4digit} four-digit groups
+	- Created {created_6digit} six-digit groups
+	- Updated {updated_8digit} eight-digit codes with parent relationships
+	"""
+
+	if errors:
+		message += f"\n- {len(errors)} errors occurred (check Error Log for details)"
+
+	frappe.msgprint(message)

--- a/cbam/utils/benchmark.py
+++ b/cbam/utils/benchmark.py
@@ -10,12 +10,12 @@ from frappe.utils import flt, today, getdate
 def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 	"""
 	Calculate country-specific CBAM benchmark with multi-tier fallback
-	
+
 	Args:
 		cn_code: CN Code (string or Link)
 		country: Country name (string or Link)
 		reference_date: Date for benchmark lookup (defaults to today)
-	
+
 	Returns:
 		dict: {
 			"benchmark_value": float or None,
@@ -33,7 +33,7 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 		"base_value": None,
 		"source": None
 	}
-	
+
 	if not cn_code or not country:
 		return {
 			"benchmark_value": None,
@@ -41,10 +41,10 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 			"details": details,
 			"warnings": ["CN Code or Country is missing"]
 		}
-	
+
 	# Determine reference year
 	from datetime import date as date_class
-	
+
 	if reference_date:
 		try:
 			ref_date = getdate(reference_date)
@@ -59,13 +59,13 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 			reference_year = date_class.today().year
 	else:
 		reference_year = date_class.today().year
-	
+
 	details["reference_year"] = reference_year
-	
+
 	try:
 		# Step 1: Get Country Default Benchmark
 		cdb = get_country_default_benchmark(country, cn_code)
-		
+
 		if not cdb:
 			# Fallback: Try global default
 			cdb = get_global_default_benchmark(cn_code)
@@ -81,13 +81,13 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 			details["source"] = "global_default"
 		else:
 			details["source"] = "country_specific"
-		
+
 		indicator = cdb.get("cbam_benchmark_indicator")
 		factor = cdb.get("benchmark_multiplication_factor", 1.0)
-		
+
 		details["indicator_used"] = indicator
 		details["factor_used"] = factor
-		
+
 		if not indicator:
 			warnings.append("Indicator missing in Country Default Benchmark")
 			return {
@@ -96,10 +96,10 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 				"details": details,
 				"warnings": warnings
 			}
-		
+
 		# Step 2: Get CBAM Benchmark
 		cbam_benchmark = get_cbam_benchmark(cn_code, indicator, reference_year)
-		
+
 		if not cbam_benchmark:
 			warnings.append(f"No CBAM Benchmark: CN {cn_code}, Indicator {indicator}, Year {reference_year}")
 			return {
@@ -108,10 +108,11 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 				"details": details,
 				"warnings": warnings
 			}
-		
+
 		base_value = cbam_benchmark.get("emission_benchmark")
 		details["base_value"] = base_value
-		
+		details["cn_code_used"] = cbam_benchmark.get("cn_code_used") or cdb.get("cn_code_used")
+
 		if base_value is None:
 			warnings.append("Emission Benchmark value is None in CBAM Benchmark")
 			return {
@@ -120,18 +121,18 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 				"details": details,
 				"warnings": warnings
 			}
-		
+
 		# Step 3: Calculate
 		result = flt(base_value) * flt(factor)
 		details["calculated_value"] = result
-		
+
 		return {
 			"benchmark_value": result,
 			"status": "Calculated",
 			"details": details,
 			"warnings": warnings
 		}
-	
+
 	except Exception as e:
 		error_msg = str(e)[:500]  # Limit error message length
 		frappe.log_error("Benchmark Calculation Error", f"Error calculating benchmark: {error_msg}")
@@ -143,109 +144,165 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 		}
 
 
+def get_cn_code_hierarchy(cn_code):
+	"""
+	Get CN code hierarchy (8-digit → 6-digit → 4-digit) for fallback lookup
+
+	Args:
+		cn_code: CN Code (string, int, or Link name)
+
+	Returns:
+		list: CN code names in order of specificity (most specific first)
+		Example: For 73181535, returns [73181535, 731815, 7318]
+	"""
+	hierarchy = []
+
+	# Normalize CN code to string
+	if isinstance(cn_code, str):
+		# Check if it's a CN Code name (Link) or numeric value
+		try:
+			# Try to get CN code value from name
+			cn_code_value = frappe.db.get_value("CN Code", cn_code, "cn_code")
+			if cn_code_value:
+				cn_code_str = str(cn_code_value)
+				cn_code_name = cn_code
+			else:
+				# If not found, assume it's a numeric string
+				cn_code_str = cn_code
+				cn_code_name = frappe.db.get_value("CN Code", {"cn_code": int(cn_code_str)}, "name") or cn_code_str
+		except (ValueError, TypeError):
+			# If conversion fails, use as-is
+			cn_code_str = cn_code
+			cn_code_name = frappe.db.get_value("CN Code", {"cn_code": int(cn_code_str)}, "name") if cn_code_str.isdigit() else cn_code_str
+	else:
+		# Integer or other type
+		cn_code_str = str(cn_code)
+		cn_code_name = frappe.db.get_value("CN Code", {"cn_code": int(cn_code_str)}, "name") or cn_code_str
+
+	cn_code_len = len(cn_code_str)
+
+	# Add the original CN code first (most specific)
+	if cn_code_name:
+		hierarchy.append(cn_code_name)
+
+	# If it's an 8-digit code, get parent hierarchy
+	if cn_code_len == 8:
+		# Get 6-digit parent (HS Subheading)
+		six_digit_code = int(cn_code_str[:6])
+		six_digit_name = frappe.db.get_value("CN Code", {"cn_code": six_digit_code, "is_group": 1}, "name")
+		if six_digit_name and six_digit_name not in hierarchy:
+			hierarchy.append(six_digit_name)
+
+		# Get 4-digit parent (HS Heading)
+		four_digit_code = int(cn_code_str[:4])
+		four_digit_name = frappe.db.get_value("CN Code", {"cn_code": four_digit_code, "is_group": 1}, "name")
+		if four_digit_name and four_digit_name not in hierarchy:
+			hierarchy.append(four_digit_name)
+
+	# If it's a 6-digit code, get 4-digit parent
+	elif cn_code_len == 6:
+		four_digit_code = int(cn_code_str[:4])
+		four_digit_name = frappe.db.get_value("CN Code", {"cn_code": four_digit_code, "is_group": 1}, "name")
+		if four_digit_name and four_digit_name not in hierarchy:
+			hierarchy.append(four_digit_name)
+
+	# Return hierarchy (most specific first)
+	return hierarchy if hierarchy else [cn_code_name] if cn_code_name else [cn_code_str]
+
+
 def get_country_default_benchmark(country, cn_code):
 	"""
 	Get Country Default Benchmark for a specific country and CN code
-	
+	With fallback to parent CN code groups (6-digit → 4-digit)
+
 	Returns:
 		dict: {
 			"cbam_benchmark_indicator": str,
-			"benchmark_multiplication_factor": float
+			"benchmark_multiplication_factor": float,
+			"cn_code_used": str  # Which CN code level was used
 		} or None
 	"""
-	# Normalize CN code - handle both Link and string formats
-	if isinstance(cn_code, str):
-		# If it's a string, it might be the CN code value or the name
-		# Try to get the CN Code name if it's a numeric value
-		try:
-			cn_code_int = int(cn_code)
-			cn_code_name = frappe.db.get_value("CN Code", {"cn_code": cn_code_int}, "name")
-			if cn_code_name:
-				cn_code = cn_code_name
-		except (ValueError, TypeError):
-			# If it's already a name or can't convert, use as is
-			pass
-	
+	# Get CN code hierarchy for fallback lookup
+	cn_code_hierarchy = get_cn_code_hierarchy(cn_code)
+
 	# Get Country Default Benchmark document
 	cdb_docs = frappe.get_all("Country Default Benchmark",
 		filters={"country": country, "is_global_default": 0},
 		fields=["name"]
 	)
-	
+
 	if not cdb_docs:
 		return None
-	
+
 	cdb_doc = frappe.get_doc("Country Default Benchmark", cdb_docs[0].name)
-	
-	# Find matching CN code in table
-	# CN code in table is a Link field, so compare with name
-	for row in cdb_doc.benchmark_values:
-		# row.cn_code is a Link field (name of CN Code doctype)
-		# Compare with the normalized cn_code
-		if row.cn_code == cn_code:
-			return {
-				"cbam_benchmark_indicator": row.cbam_benchmark_indicator,
-				"benchmark_multiplication_factor": flt(row.benchmark_multiplication_factor)
-			}
-	
+
+	# Try each CN code in hierarchy (most specific first)
+	for cn_code_to_try in cn_code_hierarchy:
+		# Find matching CN code in table
+		# CN code in table is a Link field, so compare with name
+		for row in cdb_doc.benchmark_values:
+			# row.cn_code is a Link field (name of CN Code doctype)
+			if row.cn_code == cn_code_to_try:
+				return {
+					"cbam_benchmark_indicator": row.cbam_benchmark_indicator,
+					"benchmark_multiplication_factor": flt(row.benchmark_multiplication_factor),
+					"cn_code_used": cn_code_to_try
+				}
+
 	return None
 
 
 def get_global_default_benchmark(cn_code):
 	"""
 	Get Global Default Benchmark (no country specified) for a CN code
-	
+	With fallback to parent CN code groups (6-digit → 4-digit)
+
 	Returns:
 		dict: {
 			"cbam_benchmark_indicator": str,
-			"benchmark_multiplication_factor": float
+			"benchmark_multiplication_factor": float,
+			"cn_code_used": str  # Which CN code level was used
 		} or None
 	"""
-	# Normalize CN code - handle both Link and string formats
-	if isinstance(cn_code, str):
-		# If it's a string, it might be the CN code value or the name
-		# Try to get the CN Code name if it's a numeric value
-		try:
-			cn_code_int = int(cn_code)
-			cn_code_name = frappe.db.get_value("CN Code", {"cn_code": cn_code_int}, "name")
-			if cn_code_name:
-				cn_code = cn_code_name
-		except (ValueError, TypeError):
-			# If it's already a name or can't convert, use as is
-			pass
-	
+	# Get CN code hierarchy for fallback lookup
+	cn_code_hierarchy = get_cn_code_hierarchy(cn_code)
+
 	# Get Global Default Benchmark document
 	cdb_docs = frappe.get_all("Country Default Benchmark",
 		filters={"is_global_default": 1},
 		fields=["name"]
 	)
-	
+
 	if not cdb_docs:
 		return None
-	
+
 	cdb_doc = frappe.get_doc("Country Default Benchmark", cdb_docs[0].name)
-	
-	# Find matching CN code in table
-	# CN code in table is a Link field, so compare with name
-	for row in cdb_doc.benchmark_values:
-		# row.cn_code is a Link field (name of CN Code doctype)
-		# Compare with the normalized cn_code
-		if row.cn_code == cn_code:
-			return {
-				"cbam_benchmark_indicator": row.cbam_benchmark_indicator,
-				"benchmark_multiplication_factor": flt(row.benchmark_multiplication_factor)
-			}
-	
+
+	# Try each CN code in hierarchy (most specific first)
+	for cn_code_to_try in cn_code_hierarchy:
+		# Find matching CN code in table
+		# CN code in table is a Link field, so compare with name
+		for row in cdb_doc.benchmark_values:
+			# row.cn_code is a Link field (name of CN Code doctype)
+			if row.cn_code == cn_code_to_try:
+				return {
+					"cbam_benchmark_indicator": row.cbam_benchmark_indicator,
+					"benchmark_multiplication_factor": flt(row.benchmark_multiplication_factor),
+					"cn_code_used": cn_code_to_try
+				}
+
 	return None
 
 
 def get_cbam_benchmark(cn_code, indicator, year):
 	"""
 	Get CBAM Benchmark value for a CN code, indicator, and year
-	
+	With fallback to parent CN code groups (6-digit → 4-digit)
+
 	Returns:
 		dict: {
-			"emission_benchmark": float
+			"emission_benchmark": float,
+			"cn_code_used": str  # Which CN code level was used
 		} or None
 	"""
 	# Get year value
@@ -254,36 +311,87 @@ def get_cbam_benchmark(cn_code, indicator, year):
 		year_value = frappe.db.get_value("Year", year, "year")
 	else:
 		year_value = year
-	
+
 	if not year_value:
 		return None
-	
-	# Find CBAM Benchmark with valid date range
-	cbam_docs = frappe.get_all("CBAM Benchmark",
-		filters={"cn_code": cn_code},
-		fields=["name", "valid_from_year", "valid_to_year"]
-	)
-	
-	for cbam_doc in cbam_docs:
-		from_year = frappe.db.get_value("Year", cbam_doc.valid_from_year, "year") if cbam_doc.valid_from_year else None
-		to_year = frappe.db.get_value("Year", cbam_doc.valid_to_year, "year") if cbam_doc.valid_to_year else None
-		
-		# Check if year is in range
-		if from_year and year_value < from_year:
-			continue
-		if to_year and year_value > to_year:
-			continue
-		
-		# Year is in range, get the benchmark document
-		cbam = frappe.get_doc("CBAM Benchmark", cbam_doc.name)
-		
-		# Find matching indicator
-		for row in cbam.benchmark_values:
-			if row.cbam_benchmark_indicator == indicator:
-				return {
-					"emission_benchmark": flt(row.emission_benchmark)
-				}
-	
+
+	# Get CN code hierarchy for fallback lookup
+	cn_code_hierarchy = get_cn_code_hierarchy(cn_code)
+
+	# Try each CN code in hierarchy (most specific first)
+	for cn_code_to_try in cn_code_hierarchy:
+		# Find CBAM Benchmark with valid date range
+		cbam_docs = frappe.get_all("CBAM Benchmark",
+			filters={"cn_code": cn_code_to_try},
+			fields=["name", "valid_from_year", "valid_to_year"]
+		)
+
+		for cbam_doc in cbam_docs:
+			from_year = frappe.db.get_value("Year", cbam_doc.valid_from_year, "year") if cbam_doc.valid_from_year else None
+			to_year = frappe.db.get_value("Year", cbam_doc.valid_to_year, "year") if cbam_doc.valid_to_year else None
+
+			# Check if year is in range
+			if from_year and year_value < from_year:
+				continue
+			if to_year and year_value > to_year:
+				continue
+
+			# Year is in range, get the benchmark document
+			cbam = frappe.get_doc("CBAM Benchmark", cbam_doc.name)
+
+			# Find matching indicator
+			for row in cbam.benchmark_values:
+				if row.cbam_benchmark_indicator == indicator:
+					return {
+						"emission_benchmark": flt(row.emission_benchmark),
+						"cn_code_used": cn_code_to_try
+					}
+
+	return None
+
+
+def get_standard_emission_value(cn_code, country, year):
+	"""
+	Get Standard Emission Value with fallback to parent CN code groups (6-digit → 4-digit)
+
+	Args:
+		cn_code: CN Code (string, int, or Link name)
+		country: Country name (string or Link)
+		year: Year (int, string, or Link to Year)
+
+	Returns:
+		float: emission_value or None if not found
+	"""
+	# Get year value
+	year_value = None
+	if isinstance(year, str):
+		# Check if it's a Year doctype name
+		year_value = frappe.db.get_value("Year", year, "year")
+		if not year_value:
+			# Try to parse as integer
+			try:
+				year_value = int(year)
+			except (ValueError, TypeError):
+				pass
+	else:
+		year_value = year
+
+	if not year_value:
+		return None
+
+	# Get CN code hierarchy for fallback lookup
+	cn_code_hierarchy = get_cn_code_hierarchy(cn_code)
+
+	# Try each CN code in hierarchy (most specific first)
+	for cn_code_to_try in cn_code_hierarchy:
+		sev = frappe.db.get_value(
+			"Standard Emission Value",
+			{"year": year_value, "country": country, "cn_code": cn_code_to_try},
+			"emission_value"
+		)
+		if sev is not None:
+			return flt(sev)
+
 	return None
 
 
@@ -297,7 +405,7 @@ def recalculate_good_benchmark(good_name):
 			good.country_of_origin,
 			good.hand_over_date
 		)
-		
+
 		# Use db.set_value to update directly (bypasses read-only restrictions on submitted docs)
 		if good.use_benchmark_override and good.benchmark_manual_override:
 			benchmark_value = good.benchmark_manual_override
@@ -310,7 +418,7 @@ def recalculate_good_benchmark(good_name):
 			benchmark_value = result.get("benchmark_value")
 			status = result.get("status", "Error")
 			details = json.dumps(result.get("details", {}))
-		
+
 		# Update directly in database to bypass read-only restrictions
 		frappe.db.set_value("Good", good_name, {
 			"country_specific_default_cbam_benchmark": benchmark_value,
@@ -318,9 +426,9 @@ def recalculate_good_benchmark(good_name):
 			"benchmark_calculation_details": details,
 			"benchmark_last_calculated_at": frappe.utils.now()
 		}, update_modified=False)
-		
+
 		frappe.db.commit()
-		
+
 		return {"success": True, "benchmark": benchmark_value}
 	except Exception as e:
 		error_msg = str(e)[:500]  # Limit error message length
@@ -334,7 +442,7 @@ def recalculate_external_good_benchmark(external_good_name):
 	"""Recalculate benchmark for an External Good"""
 	try:
 		eg = frappe.get_doc("External Good", external_good_name)
-		
+
 		# Use year field if available, otherwise use None
 		reference_date = None
 		if eg.year:
@@ -343,13 +451,13 @@ def recalculate_external_good_benchmark(external_good_name):
 			if year_value:
 				from datetime import date
 				reference_date = date(year_value, 1, 1)  # Use January 1st of the year
-		
+
 		result = calculate_country_specific_benchmark(
 			eg.cn_code,
 			eg.installation_country,
 			reference_date
 		)
-		
+
 		# Use db.set_value to update directly (bypasses read-only restrictions on submitted docs)
 		if eg.use_benchmark_override and eg.benchmark_manual_override:
 			benchmark_value = eg.benchmark_manual_override
@@ -362,7 +470,7 @@ def recalculate_external_good_benchmark(external_good_name):
 			benchmark_value = result.get("benchmark_value")
 			status = result.get("status", "Error")
 			details = json.dumps(result.get("details", {}))
-		
+
 		# Update directly in database to bypass read-only restrictions
 		frappe.db.set_value("External Good", external_good_name, {
 			"country_specific_default_cbam_benchmark": benchmark_value,
@@ -370,9 +478,9 @@ def recalculate_external_good_benchmark(external_good_name):
 			"benchmark_calculation_details": details,
 			"benchmark_last_calculated_at": frappe.utils.now()
 		}, update_modified=False)
-		
+
 		frappe.db.commit()
-		
+
 		return {"success": True, "benchmark": benchmark_value}
 	except Exception as e:
 		error_msg = str(e)[:500]  # Limit error message length
@@ -385,7 +493,7 @@ def recalculate_external_good_benchmark(external_good_name):
 def batch_update_benchmarks(cn_code=None, country=None):
 	"""
 	Batch update benchmarks for all goods
-	
+
 	Args:
 		cn_code: Optional CN code filter
 		country: Optional country filter
@@ -395,12 +503,12 @@ def batch_update_benchmarks(cn_code=None, country=None):
 		filters["cn_code"] = cn_code
 	if country:
 		filters["country_of_origin"] = country
-	
+
 	goods = frappe.get_all("Good", filters=filters, fields=["name"])
-	
+
 	updated = 0
 	errors = 0
-	
+
 	for good in goods:
 		try:
 			result = recalculate_good_benchmark(good.name)
@@ -413,7 +521,7 @@ def batch_update_benchmarks(cn_code=None, country=None):
 			error_msg = str(e)[:500]
 			title = f"Error updating Good {good.name}"[:140]
 			frappe.log_error(title, f"Good: {good.name}\nError: {error_msg}")
-	
+
 	return {
 		"updated": updated,
 		"errors": errors,
@@ -425,13 +533,13 @@ def update_affected_goods_by_cn_code(cn_code):
 	"""
 	Update all goods and external goods with a specific CN code
 	Called when CBAM Benchmark changes
-	
+
 	Args:
 		cn_code: CN Code to update goods for
 	"""
 	if not cn_code:
 		return
-	
+
 	# Get all goods with this CN code (exclude submitted and cancelled)
 	goods = frappe.get_all("Good",
 		filters={
@@ -441,7 +549,7 @@ def update_affected_goods_by_cn_code(cn_code):
 		},
 		fields=["name"]
 	)
-	
+
 	# Get all external goods with this CN code (exclude submitted and cancelled)
 	external_goods = frappe.get_all("External Good",
 		filters={
@@ -450,12 +558,12 @@ def update_affected_goods_by_cn_code(cn_code):
 		},
 		fields=["name"]
 	)
-	
+
 	total_count = len(goods) + len(external_goods)
-	
+
 	if total_count == 0:
 		return
-	
+
 	# Use background job for large updates
 	if total_count > 100:
 		frappe.enqueue(
@@ -473,7 +581,7 @@ def update_affected_goods_by_cn_code(cn_code):
 				error_msg = str(e)[:500]
 				title = f"Error updating Good {good.name}"[:140]
 				frappe.log_error(title, f"Good: {good.name}\nError: {error_msg}")
-		
+
 		for eg in external_goods:
 			try:
 				recalculate_external_good_benchmark(eg.name)
@@ -481,7 +589,7 @@ def update_affected_goods_by_cn_code(cn_code):
 				error_msg = str(e)[:500]
 				title = f"Error updating Ext Good {eg.name}"[:140]
 				frappe.log_error(title, f"External Good: {eg.name}\nError: {error_msg}")
-		
+
 		# Ensure all updates are committed
 		frappe.db.commit()
 
@@ -490,13 +598,13 @@ def update_affected_goods_by_country(country):
 	"""
 	Update all goods and external goods with a specific country
 	Called when Country Default Benchmark changes
-	
+
 	Args:
 		country: Country to update goods for
 	"""
 	if not country:
 		return
-	
+
 	# Get all goods with this country of origin (exclude submitted and cancelled)
 	goods = frappe.get_all("Good",
 		filters={
@@ -506,7 +614,7 @@ def update_affected_goods_by_country(country):
 		},
 		fields=["name"]
 	)
-	
+
 	# Get all external goods with this installation country (exclude submitted and cancelled)
 	external_goods = frappe.get_all("External Good",
 		filters={
@@ -515,12 +623,12 @@ def update_affected_goods_by_country(country):
 		},
 		fields=["name"]
 	)
-	
+
 	total_count = len(goods) + len(external_goods)
-	
+
 	if total_count == 0:
 		return
-	
+
 	# Use background job for large updates
 	if total_count > 100:
 		frappe.enqueue(
@@ -538,7 +646,7 @@ def update_affected_goods_by_country(country):
 				error_msg = str(e)[:500]
 				title = f"Error updating Good {good.name}"[:140]
 				frappe.log_error(title, f"Good: {good.name}\nError: {error_msg}")
-		
+
 		for eg in external_goods:
 			try:
 				recalculate_external_good_benchmark(eg.name)
@@ -551,25 +659,25 @@ def update_affected_goods_by_country(country):
 @frappe.whitelist()
 def batch_update_benchmarks_by_cn_code(cn_code):
 	"""Background job to update benchmarks for a CN code"""
-	goods = frappe.get_all("Good", 
+	goods = frappe.get_all("Good",
 		filters={
 			"cn_code": cn_code,
 			"status": ["not in", ["Data Submitted", "Cancelled"]],
 			"docstatus": ["not in", [1, 2]]  # Not submitted (1) or cancelled (2)
-		}, 
+		},
 		fields=["name"]
 	)
-	external_goods = frappe.get_all("External Good", 
+	external_goods = frappe.get_all("External Good",
 		filters={
 			"cn_code": cn_code,
 			"docstatus": ["not in", [1, 2]]  # Not submitted (1) or cancelled (2)
-		}, 
+		},
 		fields=["name"]
 	)
-	
+
 	updated = 0
 	errors = 0
-	
+
 	for good in goods:
 		try:
 			result = recalculate_good_benchmark(good.name)
@@ -580,7 +688,7 @@ def batch_update_benchmarks_by_cn_code(cn_code):
 			error_msg = str(e)[:500]
 			title = f"Error updating Good {good.name}"[:140]
 			frappe.log_error(title, f"Good: {good.name}\nError: {error_msg}")
-	
+
 	for eg in external_goods:
 		try:
 			result = recalculate_external_good_benchmark(eg.name)
@@ -591,35 +699,35 @@ def batch_update_benchmarks_by_cn_code(cn_code):
 			error_msg = str(e)[:500]
 			title = f"Error updating Ext Good {eg.name}"[:140]
 			frappe.log_error(title, f"External Good: {eg.name}\nError: {error_msg}")
-	
+
 	# Ensure all updates are committed
 	frappe.db.commit()
-	
+
 	return {"updated": updated, "errors": errors, "total": len(goods) + len(external_goods)}
 
 
 @frappe.whitelist()
 def batch_update_benchmarks_by_country(country):
 	"""Background job to update benchmarks for a country"""
-	goods = frappe.get_all("Good", 
+	goods = frappe.get_all("Good",
 		filters={
 			"country_of_origin": country,
 			"status": ["not in", ["Data Submitted", "Cancelled"]],
 			"docstatus": ["not in", [1, 2]]  # Not submitted (1) or cancelled (2)
-		}, 
+		},
 		fields=["name"]
 	)
-	external_goods = frappe.get_all("External Good", 
+	external_goods = frappe.get_all("External Good",
 		filters={
 			"installation_country": country,
 			"docstatus": ["not in", [1, 2]]  # Not submitted (1) or cancelled (2)
-		}, 
+		},
 		fields=["name"]
 	)
-	
+
 	updated = 0
 	errors = 0
-	
+
 	for good in goods:
 		try:
 			result = recalculate_good_benchmark(good.name)
@@ -630,7 +738,7 @@ def batch_update_benchmarks_by_country(country):
 			error_msg = str(e)[:500]
 			title = f"Error updating Good {good.name}"[:140]
 			frappe.log_error(title, f"Good: {good.name}\nError: {error_msg}")
-	
+
 	for eg in external_goods:
 		try:
 			result = recalculate_external_good_benchmark(eg.name)
@@ -641,9 +749,9 @@ def batch_update_benchmarks_by_country(country):
 			error_msg = str(e)[:500]
 			title = f"Error updating Ext Good {eg.name}"[:140]
 			frappe.log_error(title, f"External Good: {eg.name}\nError: {error_msg}")
-	
+
 	# Ensure all updates are committed
 	frappe.db.commit()
-	
+
 	return {"updated": updated, "errors": errors, "total": len(goods) + len(external_goods)}
 


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/674
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/673

## Overview

This PR implements hierarchical CN Code grouping (similar to Chart of Accounts) with automatic fallback logic for CBAM Benchmark and Standard Emission Value lookups. CN codes can now be organized in a tree structure (4-digit → 6-digit → 8-digit), and the system automatically falls back to parent group levels when specific benchmarks or emission values are not found.

## Requirements Addressed

1. ✅ **CN Code Tree Structure**: Enable hierarchical organization of CN codes with "is Group" functionality
2. ✅ **CBAM Benchmark Fallback**: If no benchmark exists for 8-digit CN code, automatically use benchmark from 6-digit or 4-digit parent group
3. ✅ **Standard Emission Value Fallback**: If no SEV exists for 8-digit CN code, automatically use SEV from 6-digit or 4-digit parent group

## Key Features

### 1. CN Code Doctype Enhancement
- Added tree view support (`is_tree: 1`)
- Added `parent_cn_code` field for hierarchical relationships
- Added `is_group` field (auto-managed based on CN code length)
- Validation rules:
  - 4-digit and 6-digit codes must be groups
  - 8-digit codes cannot be groups
  - Parent must be a prefix of child
  - Enforces hierarchy: 4-digit → 6-digit → 8-digit

### 2. Automatic Fallback Logic
- **CBAM Benchmark**: Falls back from 8-digit → 6-digit → 4-digit when looking up benchmarks
- **Standard Emission Value**: Falls back from 8-digit → 6-digit → 4-digit when looking up SEV
- Works automatically in:
  - Good/External Good benchmark calculations
  - Financial Dashboard
  - Financial Evaluation Report

### 3. Data Migration
- Migration script organizes existing 8-digit CN codes into tree structure
- Automatically creates parent 4-digit and 6-digit groups
- Sets up parent-child relationships

## Files Changed

### New Files
- `apps/cbam/cbam/patches/v15_4_4/add_cn_code_tree_structure.py` - Migration script

### Modified Files

#### Core Doctype Changes
- `apps/cbam/cbam/cbam/doctype/cn_code/cn_code.json` - Added tree structure fields
- `apps/cbam/cbam/cbam/doctype/cn_code/cn_code.py` - Added validation logic
- `apps/cbam/cbam/cbam/doctype/cn_code/cn_code.js` - Auto-set is_group based on length

#### Benchmark Logic
- `apps/cbam/cbam/utils/benchmark.py`:
  - Added `get_cn_code_hierarchy()` - Returns hierarchy list [8-digit, 6-digit, 4-digit]
  - Updated `get_country_default_benchmark()` - Uses hierarchy fallback
  - Updated `get_global_default_benchmark()` - Uses hierarchy fallback
  - Updated `get_cbam_benchmark()` - Uses hierarchy fallback
  - Added `get_standard_emission_value()` - SEV lookup with fallback

#### Financial Reports
- `apps/cbam/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py` - Uses SEV fallback
- `apps/cbam/cbam/cbam/report/financial_evaluation/financial_evaluation.py` - Uses SEV fallback

#### Configuration
- `apps/cbam/cbam/patches.txt` - Added v15_4_4 patch entry

## Technical Implementation

### CN Code Hierarchy Structure

```
7318 (4-digit) - HS Heading (Group)
  └── 731815 (6-digit) - HS Subheading (Group)
      └── 73181535 (8-digit) - CN Code (Leaf)
```

### Fallback Logic Flow

**Example: CN Code 73181535**

1. Try 8-digit: `73181535` → Not found
2. Try 6-digit parent: `731815` → ✅ Found! Use this
3. If still not found, try 4-digit parent: `7318`

### Code Splitting Logic

```python
# For 8-digit code: 73181535
six_digit_code = int(cn_code_str[:6])   # Result: 731815
four_digit_code = int(cn_code_str[:4])  # Result: 7318
```
