### PR TITLE
gallehr/cbam#664: Rejection Flow Updates

### DIFF
--- a/cbam/cbam/doctype/good/good.js
+++ b/cbam/cbam/doctype/good/good.js
@@ -284,6 +284,12 @@ frappe.ui.form.on("Good Default Emission Value", {
     }
 });
 
+frappe.ui.form.on("Good", {
+    refresh(frm) {
+        show_rejection_banner(frm);
+    }
+});
+
 function highlight_applicable_product_rows(frm) {
     const grid = frm.fields_dict.country_specific_default_emission_values?.grid;
     if (!grid || !grid.grid_rows || grid.grid_rows.length === 0) {
@@ -296,4 +302,20 @@ function highlight_applicable_product_rows(frm) {
             $(grid_row.row).toggleClass("applicable-product-row", !!row.applicable_product);
         }
     });
+}
+
+function show_rejection_banner(frm) {
+    if (frm.doc.status !== "Rejected") {
+        frm.dashboard.clear_headline();
+        return;
+    }
+    let message = "";
+    if (frm.doc.rejected_within_supply_chain) {
+        message = __("This good has been rejected within the supply chain and has not been rejected to the Declarant.");
+    } else if (frm.doc.rejected_to_declarant) {
+        message = __("This good has been rejected back to the Declarant.");
+    }
+    if (message) {
+        frm.dashboard.set_headline(message);
+    }
 }

--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -67,6 +67,9 @@
   "rejection_details_section",
   "rejected_from_supplier",
   "rejection_reason",
+  "rejection_flags_section",
+  "rejected_within_supply_chain",
+  "rejected_to_declarant",
   "split_details_section",
   "split_details",
   "requested_data_section",
@@ -355,6 +358,27 @@
    "options": "Operating Company",
    "read_only": 1,
    "read_only_depends_on": "eval:!frappe.user.has_role(\"System Manager\")"
+  },
+  {
+   "depends_on": "eval:doc.status == \"Rejected\"",
+   "fieldname": "rejection_flags_section",
+   "fieldtype": "Section Break",
+   "label": "Rejection Flags"
+  },
+  {
+   "default": "0",
+   "fieldname": "rejected_within_supply_chain",
+   "fieldtype": "Check",
+   "label": "Good rejected within Supply Chain",
+   "description": "This good has been rejected within the supply chain i.e. has not been rejected to Declarant.",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "rejected_to_declarant",
+   "fieldtype": "Check",
+   "label": "Rejected to Declarant",
+   "read_only": 1
   },
   {
    "fieldname": "split_details_section",

--- a/cbam/cbam/doctype/good/good.py
+++ b/cbam/cbam/doctype/good/good.py
@@ -26,6 +26,7 @@ class Good(Document):
 
 		self.update_name()
 		self.calculate_benchmark()
+		self.update_rejection_flags()
 		self.calculate_default_emission_values()
 
 	def update_name(self):
@@ -151,6 +152,25 @@ class Good(Document):
 					child.applicable_product = 1
 
 		self._sync_default_emission_selection_status()
+
+	def update_rejection_flags(self):
+		"""Set rejection flags for declarant visibility."""
+		if self.status != "Rejected":
+			self.rejected_within_supply_chain = 0
+			self.rejected_to_declarant = 0
+			return
+
+		if not self.rejected_from_supplier or not self.operating_company:
+			self.rejected_within_supply_chain = 0
+			self.rejected_to_declarant = 0
+			return
+
+		if self.rejected_from_supplier == self.operating_company:
+			self.rejected_within_supply_chain = 0
+			self.rejected_to_declarant = 1
+		else:
+			self.rejected_within_supply_chain = 1
+			self.rejected_to_declarant = 0
 
 	def _sync_default_emission_selection_status(self):
 		applicable_rows = [row for row in self.country_specific_default_emission_values if row.applicable_product]

--- a/cbam/cbam/doctype/good/good_list.js
+++ b/cbam/cbam/doctype/good/good_list.js
@@ -8,7 +8,7 @@ frappe.listview_settings['Good'] = {
                 method: "cbam.cbam.doctype.good.good.send_data_request",
                 args:{
                     goods: listview.get_checked_items()
-                }, 
+                },
                 freeze: true,
                 freeze_message: "Sending Data Request, please wait.",
                 callback(r){
@@ -16,8 +16,14 @@ frappe.listview_settings['Good'] = {
                 }
             })
         });
+
+        if (frappe.user.has_role("Declarant")) {
+            listview.page.add_action_item(__("Filter: Rejected within Supply Chain"), function() {
+                listview.filter_area.add([["Good", "rejected_within_supply_chain", "=", 1]]);
+            });
+        }
     }
 };
 
 
-  
+


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/664
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/660

## Overview
- Added explicit rejection flags to distinguish supply-chain rejection vs. rejection back to Declarant.
- Added a banner on the Good form to show rejection type.
- Added a Declarant list filter for “Rejected within Supply Chain”.

## Data Model Changes
- New read‑only flags on `Good`:
  - `rejected_within_supply_chain`
  - `rejected_to_declarant`

## Logic Changes
- `Good.update_rejection_flags()` computes flags on save:
  - If status != Rejected → both flags off.
  - If `rejected_from_supplier == operating_company` → rejected back to Declarant.
  - Else → rejected within supply chain.

## UI Changes
- Good form banner shows rejection context in Desk view.
- Declarant list action: **Filter: Rejected within Supply Chain**.

---