### PR TITLE
gallehr/cbam#680: Add year‑based highlighting

### DIFF
--- a/cbam/cbam/doctype/external_good/external_good.js
+++ b/cbam/cbam/doctype/external_good/external_good.js
@@ -33,6 +33,13 @@ frappe.ui.form.on("External Good", {
       show_benchmark_status_eg(frm);
     }
     update_external_default_emission_toggle(frm);
+    highlight_external_applicable_product_rows(frm);
+  },
+  year(frm) {
+    if (frm.__external_good_year_cache) {
+      frm.__external_good_year_cache = null;
+    }
+    highlight_external_applicable_product_rows(frm);
   },
   raw_mass_tonne(frm) {
       if (frm.doc.raw_mass_tonne != null) {
@@ -92,6 +99,10 @@ frappe.ui.form.on("External Good Default Emission Value", {
     });
     frm.refresh_field("country_specific_default_emission_values");
     frm.set_value("select_applicable_product_for_cn_code", 0);
+    highlight_external_applicable_product_rows(frm);
+  },
+  form_render(frm, cdt, cdn) {
+    highlight_external_applicable_product_rows(frm);
   }
 });
 
@@ -105,6 +116,92 @@ function calculate_mass_per_article(frm) {
   if (frm.doc.raw_mass && frm.doc.quantity_of_articles) {
     frm.set_value('mass_per_article', frm.doc.raw_mass / frm.doc.quantity_of_articles);
   }
+}
+
+function highlight_external_applicable_product_rows(frm) {
+  const grid = frm.fields_dict.country_specific_default_emission_values?.grid;
+  if (!grid || !grid.grid_rows || grid.grid_rows.length === 0) {
+    setTimeout(() => highlight_external_applicable_product_rows(frm), 150);
+    return;
+  }
+  get_external_good_year_value(frm).then(year_value => {
+    const year_field = get_external_default_emission_year_field(year_value);
+    (frm.doc.country_specific_default_emission_values || []).forEach(row => {
+      const grid_row = grid.get_row(row.name);
+      if (!grid_row || !grid_row.row) {
+        return;
+      }
+      const $row = $(grid_row.row);
+      $row.toggleClass("applicable-product-row", !!row.applicable_product);
+      $row.find(".applicable-product-year").removeClass("applicable-product-year");
+      if (row.applicable_product && year_field) {
+        $row.find(`[data-fieldname="${year_field}"]`).addClass("applicable-product-year");
+      }
+      highlight_external_applicable_product_form(grid_row, row.applicable_product, year_field);
+    });
+  });
+}
+
+function highlight_external_applicable_product_form(grid_row, is_applicable, year_field) {
+  if (!grid_row || !grid_row.grid_form || !grid_row.grid_form.fields_dict) {
+    return;
+  }
+  const fields = [
+    "default_value_total_emissions",
+    "default_value_2026",
+    "default_value_2027",
+    "default_value_2028_onwards"
+  ];
+  fields.forEach(fieldname => {
+    const field = grid_row.grid_form.fields_dict[fieldname];
+    if (!field || !field.$wrapper) {
+      return;
+    }
+    field.$wrapper.removeClass("applicable-product-year");
+    field.$wrapper.find(".control-label, input, .input-with-feedback, .static-area")
+      .removeClass("applicable-product-year");
+  });
+  if (!is_applicable || !year_field) {
+    return;
+  }
+  const target = grid_row.grid_form.fields_dict[year_field];
+  if (!target || !target.$wrapper) {
+    return;
+  }
+  target.$wrapper.addClass("applicable-product-year");
+  target.$wrapper.find(".control-label, input, .input-with-feedback, .static-area")
+    .addClass("applicable-product-year");
+}
+
+function get_external_default_emission_year_field(year) {
+  if (!year) {
+    return "default_value_total_emissions";
+  }
+  if (year === 2026) {
+    return "default_value_2026";
+  }
+  if (year === 2027) {
+    return "default_value_2027";
+  }
+  if (year === 2028) {
+    return "default_value_2028_onwards";
+  }
+  return "default_value_total_emissions";
+}
+
+function get_external_good_year_value(frm) {
+  const year_link = frm.doc.year;
+  if (!year_link) {
+    return Promise.resolve(null);
+  }
+  if (frm.__external_good_year_cache?.name === year_link) {
+    return Promise.resolve(frm.__external_good_year_cache.year);
+  }
+  return frappe.db.get_value("Year", year_link, "year").then(year_res => {
+    const year_value = year_res && year_res.message ? parseInt(year_res.message.year, 10) : null;
+    frm.__external_good_year_cache = { name: year_link, year: year_value };
+    return year_value;
+  });
 }
 
 add_custom_links = (fieldname, doctype, docname, doctype_label) => {

--- a/cbam/cbam/doctype/external_good/external_good.py
+++ b/cbam/cbam/doctype/external_good/external_good.py
@@ -101,11 +101,16 @@ class ExternalGood(Document):
 	def calculate_default_emission_values(self):
 		"""Populate default emission values from Country Default Values"""
 		if not self.cn_code or not self.installation_country:
-			self.country_specific_default_emission_values = []
-			self.select_applicable_product_for_cn_code = 0
+			if not self.country_specific_default_emission_values:
+				self.country_specific_default_emission_values = []
+				self.select_applicable_product_for_cn_code = 0
 			return
 
-		should_refresh = self.is_new() or self.has_value_changed("cn_code") or self.has_value_changed("installation_country")
+		should_refresh = (
+			self.has_value_changed("cn_code")
+			or self.has_value_changed("installation_country")
+			or not self.country_specific_default_emission_values
+		)
 		selected_key = None
 		if self.country_specific_default_emission_values:
 			for row in self.country_specific_default_emission_values:

--- a/cbam/cbam/doctype/good/good.js
+++ b/cbam/cbam/doctype/good/good.js
@@ -31,11 +31,17 @@ frappe.ui.form.on('Good', {
         if (frm.doc.benchmark_calculation_status) {
             show_benchmark_status(frm);
         }
-		highlight_applicable_product_rows(frm);
+        highlight_applicable_product_rows(frm);
     },
 	onload(frm) {
 		highlight_applicable_product_rows(frm);
 	},
+    internal_customs_import_number(frm) {
+        if (frm.__customs_import_year_cache) {
+            frm.__customs_import_year_cache = null;
+        }
+        highlight_applicable_product_rows(frm);
+    },
     raw_mass(frm) {
         if (frm.doc.raw_mass != null) {
             const value = flt(frm.doc.raw_mass) / 1000;
@@ -281,6 +287,9 @@ frappe.ui.form.on("Good Default Emission Value", {
         frm.refresh_field("country_specific_default_emission_values");
         frm.set_value("select_applicable_product_for_cn_code", 0);
         highlight_applicable_product_rows(frm);
+    },
+    form_render(frm, cdt, cdn) {
+        highlight_applicable_product_rows(frm);
     }
 });
 
@@ -296,12 +305,95 @@ function highlight_applicable_product_rows(frm) {
         setTimeout(() => highlight_applicable_product_rows(frm), 150);
         return;
     }
-    (frm.doc.country_specific_default_emission_values || []).forEach(row => {
-        const grid_row = grid.get_row(row.name);
-        if (grid_row && grid_row.row) {
-            $(grid_row.row).toggleClass("applicable-product-row", !!row.applicable_product);
-        }
+    get_customs_import_year(frm).then(customs_year => {
+        const year_field = get_default_emission_year_field(customs_year);
+        (frm.doc.country_specific_default_emission_values || []).forEach(row => {
+            const grid_row = grid.get_row(row.name);
+            if (!grid_row || !grid_row.row) {
+                return;
+            }
+            const $row = $(grid_row.row);
+            $row.toggleClass("applicable-product-row", !!row.applicable_product);
+            $row.find(".applicable-product-year").removeClass("applicable-product-year");
+            if (row.applicable_product && year_field) {
+                $row.find(`[data-fieldname="${year_field}"]`).addClass("applicable-product-year");
+            }
+            highlight_applicable_product_form(grid_row, row.applicable_product, year_field);
+        });
     });
+}
+
+function highlight_applicable_product_form(grid_row, is_applicable, year_field) {
+    if (!grid_row || !grid_row.grid_form || !grid_row.grid_form.fields_dict) {
+        return;
+    }
+    const fields = [
+        "default_value_total_emissions",
+        "default_value_2026",
+        "default_value_2027",
+        "default_value_2028_onwards"
+    ];
+    fields.forEach(fieldname => {
+        const field = grid_row.grid_form.fields_dict[fieldname];
+        if (!field || !field.$wrapper) {
+            return;
+        }
+        field.$wrapper.removeClass("applicable-product-year");
+        field.$wrapper.find(".control-label, input, .input-with-feedback, .static-area")
+            .removeClass("applicable-product-year");
+    });
+    if (!is_applicable || !year_field) {
+        return;
+    }
+    const target = grid_row.grid_form.fields_dict[year_field];
+    if (!target || !target.$wrapper) {
+        return;
+    }
+    target.$wrapper.addClass("applicable-product-year");
+    target.$wrapper.find(".control-label, input, .input-with-feedback, .static-area")
+        .addClass("applicable-product-year");
+}
+
+function get_default_emission_year_field(year) {
+    if (!year) {
+        return null;
+    }
+    if (year < 2026) {
+        return "default_value_total_emissions";
+    }
+    if (year === 2026) {
+        return "default_value_2026";
+    }
+    if (year === 2027) {
+        return "default_value_2027";
+    }
+    if (year === 2028) {
+        return "default_value_2028_onwards";
+    }
+    return "default_value_total_emissions";
+}
+
+function get_customs_import_year(frm) {
+    const customs_import = frm.doc.internal_customs_import_number;
+    if (!customs_import) {
+        return Promise.resolve(null);
+    }
+    if (frm.__customs_import_year_cache?.name === customs_import) {
+        return Promise.resolve(frm.__customs_import_year_cache.year);
+    }
+    return frappe.db.get_value("Customs Import", customs_import, "year")
+        .then(res => {
+            const year_link = res && res.message ? res.message.year : null;
+            if (!year_link) {
+                frm.__customs_import_year_cache = { name: customs_import, year: null };
+                return null;
+            }
+            return frappe.db.get_value("Year", year_link, "year").then(year_res => {
+                const year_value = year_res && year_res.message ? parseInt(year_res.message.year, 10) : null;
+                frm.__customs_import_year_cache = { name: customs_import, year: year_value };
+                return year_value;
+            });
+        });
 }
 
 function show_rejection_banner(frm) {

--- a/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py
+++ b/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py
@@ -132,7 +132,9 @@ def fetch_cbam_report_rows(cbam_reports, from_year, to_year):
                 bench_mark = extract_numeric_value(getattr(eg, "country_specific_default_cbam_benchmark", None) or 0.0)
                 # Round to 4 decimal places (German calculation standard)
                 bench_mark = round(bench_mark, 4)
-                sev_key = (report_year, installation_country, cn_code)
+                from cbam.utils.benchmark import resolve_report_year
+                default_emission_year = resolve_report_year(getattr(eg, "year", None) or report_year) or report_year
+                sev_key = (default_emission_year, installation_country, cn_code)
 
                 if sev_key not in default_emission_value_cache:
                     sev_value = None
@@ -154,12 +156,12 @@ def fetch_cbam_report_rows(cbam_reports, from_year, to_year):
                     selected_rows = default_emission_rows_cache[eg.name]
                     applicable = [row for row in selected_rows if row.get("applicable_product")]
                     if len(applicable) == 1:
-                        sev_value = pick_default_emission_value(applicable[0], report_year)
+                        sev_value = pick_default_emission_value(applicable[0], default_emission_year)
                     elif len(selected_rows) == 1:
-                        sev_value = pick_default_emission_value(selected_rows[0], report_year)
+                        sev_value = pick_default_emission_value(selected_rows[0], default_emission_year)
                     if sev_value is None:
                         from cbam.utils.benchmark import get_default_emission_value
-                        sev_value = get_default_emission_value(installation_country, cn_code, report_year)
+                        sev_value = get_default_emission_value(installation_country, cn_code, default_emission_year)
                     default_emission_value_cache[sev_key] = sev_value or 0.0
 
                 default_emission_value = extract_numeric_value(default_emission_value_cache[sev_key])

--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
@@ -161,7 +161,8 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                     NULL AS good_name,
                     eg.name,
                     'CBAM Report Data' as data_source,
-                    eg.reporting_period as reporting_period
+                    eg.reporting_period as reporting_period,
+                    eg.year as external_good_year
                 FROM `tabExternal Good` eg
                 {where_sql_eg}
                 UNION
@@ -175,7 +176,8 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                     g.name AS good_name,
                     g.name,
                     'Supplier Data' as data_source,
-                    g.internal_customs_import_number as reporting_period
+                    g.internal_customs_import_number as reporting_period,
+                    NULL as external_good_year
                 FROM `tabGood` g
                 {where_sql}
             ) AS main_table
@@ -230,11 +232,16 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
         external_good_names = [row.get("name") for row in data if not row.get("good_name")]
         default_values_by_good = get_good_default_emission_values(good_names)
         default_values_by_external_good = get_external_good_default_emission_values(external_good_names)
-        reporting_periods = [row.get("reporting_period") for row in data if row.get("good_name") and row.get("reporting_period")]
+        reporting_periods = [row.get("reporting_period") for row in data if row.get("reporting_period")]
         reporting_years = get_customs_import_year_map(reporting_periods)
 
         for row in data:
-            report_year = reporting_years.get(row.get("reporting_period")) or year
+            from cbam.utils.benchmark import resolve_report_year
+            report_year = (
+                resolve_report_year(row.get("external_good_year"))
+                or reporting_years.get(row.get("reporting_period"))
+                or year
+            )
             default_value = None
             if row.get("good_name"):
                 good_rows = default_values_by_good.get(row.get("good_name"), [])

--- a/cbam/cbam/report/financial_evaluation/financial_evaluation.py
+++ b/cbam/cbam/report/financial_evaluation/financial_evaluation.py
@@ -193,6 +193,7 @@ def get_data(filters=None):
             COALESCE(eg.country_specific_default_cbam_benchmark, 0.0) AS bench_mark,
             NULL AS good_name,
             eg.reporting_period,
+            eg.year as external_good_year,
             IFNULL(cbam.cbam_factor,0.0) AS cbam_factor,
             {ets_carbon_price} as ets_carbon_price,
             ((
@@ -227,6 +228,7 @@ def get_data(filters=None):
             COALESCE(g.country_specific_default_cbam_benchmark, 0.0) AS bench_mark,
             g.name AS good_name,
             g.internal_customs_import_number as reporting_period,
+            NULL as external_good_year,
             IFNULL(cbam.cbam_factor,0.0) AS cbam_factor,
             {ets_carbon_price} as ets_carbon_price,
             ((
@@ -253,7 +255,7 @@ def get_data(filters=None):
     external_good_names = [row.get("name") for row in data if not row.get("good_name")]
     default_values_by_good = get_good_default_emission_values(good_names)
     default_values_by_external_good = get_external_good_default_emission_values(external_good_names)
-    reporting_periods = [row.get("reporting_period") for row in data if row.get("good_name") and row.get("reporting_period")]
+    reporting_periods = [row.get("reporting_period") for row in data if row.get("reporting_period")]
     reporting_years = get_customs_import_year_map(reporting_periods)
 
     for row in data:
@@ -268,7 +270,11 @@ def get_data(filters=None):
                 if row.get("bench_mark") is not None:
                     row["bench_mark"] = round(float(row["bench_mark"]), 4)
 
-                report_year = reporting_years.get(row.get("reporting_period"))
+                from cbam.utils.benchmark import resolve_report_year
+                report_year = (
+                    resolve_report_year(row.get("external_good_year"))
+                    or reporting_years.get(row.get("reporting_period"))
+                )
                 if row.get("good_name"):
                     default_rows = default_values_by_good.get(row.get("good_name"), [])
                     default_value = select_default_emission_value(default_rows, report_year)

--- a/cbam/public/css/cbam.css
+++ b/cbam/public/css/cbam.css
@@ -1,3 +1,18 @@
 .applicable-product-row {
     background-color: #e8f5e9 !important;
 }
+
+.applicable-product-year {
+    background-color: #fff8e1 !important;
+}
+
+.applicable-product-year.control-label,
+.applicable-product-year .control-label {
+    color: #8a5a00 !important;
+    font-weight: 600;
+}
+
+.applicable-product-year .static-area,
+.applicable-product-year input {
+    background-color: #fff8e1 !important;
+}

--- a/cbam/utils/benchmark.py
+++ b/cbam/utils/benchmark.py
@@ -308,21 +308,38 @@ def _serialize_default_emission_row(row):
 	}
 
 
+def resolve_report_year(report_year):
+	"""Resolve report year from int, string, or Year link."""
+	if not report_year:
+		return None
+	if isinstance(report_year, int):
+		return report_year
+	if isinstance(report_year, str):
+		try:
+			return int(report_year)
+		except ValueError:
+			year_value = frappe.db.get_value("Year", report_year, "year")
+			return int(year_value) if year_value else None
+	if hasattr(report_year, "year"):
+		try:
+			return int(report_year.year)
+		except (TypeError, ValueError):
+			return None
+	return None
+
+
 def pick_default_emission_value(row, report_year):
 	"""Pick default emission value based on reporting year."""
 	if not row:
 		return None
 
-	try:
-		year_value = int(report_year) if report_year else None
-	except (ValueError, TypeError):
-		year_value = None
+	year_value = resolve_report_year(report_year)
 
 	if year_value == 2026 and row.get("default_value_2026") is not None:
 		return row.get("default_value_2026")
 	if year_value == 2027 and row.get("default_value_2027") is not None:
 		return row.get("default_value_2027")
-	if year_value and year_value >= 2028 and row.get("default_value_2028_onwards") is not None:
+	if year_value == 2028 and row.get("default_value_2028_onwards") is not None:
 		return row.get("default_value_2028_onwards")
 
 	return row.get("default_value_total_emissions")


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/680
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/672

**Summary**

- Add year‑based highlighting for Default Emission Values in both Good and External Good, including total emissions fallback.
- Align backend default emission selection with the same year logic (2026/2027/2028, else total emissions), including External Good year precedence in reports.
- Prevent External Good default emission values from being cleared unless key inputs change.