### PR TITLE
gallehr/cbam#680: fixed  default/fall back logic for year

### DIFF
--- a/cbam/cbam/doctype/external_good/external_good.js
+++ b/cbam/cbam/doctype/external_good/external_good.js
@@ -183,7 +183,7 @@ function get_external_default_emission_year_field(year) {
   if (year === 2027) {
     return "default_value_2027";
   }
-  if (year === 2028) {
+  if (year >= 2028) {
     return "default_value_2028_onwards";
   }
   return "default_value_total_emissions";

--- a/cbam/cbam/doctype/good/good.js
+++ b/cbam/cbam/doctype/good/good.js
@@ -367,7 +367,7 @@ function get_default_emission_year_field(year) {
     if (year === 2027) {
         return "default_value_2027";
     }
-    if (year === 2028) {
+    if (year >= 2028) {
         return "default_value_2028_onwards";
     }
     return "default_value_total_emissions";

--- a/cbam/utils/benchmark.py
+++ b/cbam/utils/benchmark.py
@@ -339,7 +339,7 @@ def pick_default_emission_value(row, report_year):
 		return row.get("default_value_2026")
 	if year_value == 2027 and row.get("default_value_2027") is not None:
 		return row.get("default_value_2027")
-	if year_value == 2028 and row.get("default_value_2028_onwards") is not None:
+	if year_value and year_value >= 2028 and row.get("default_value_2028_onwards") is not None:
 		return row.get("default_value_2028_onwards")
 
 	return row.get("default_value_total_emissions")


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/680
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/672

**Summary**

update the default/fall back logic to ensure the 2028 value is used for all customs import/ reporting periods \>2027