### PR TITLE
fix: show internal goods and restore exposure chart

### DIFF
--- a/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py
+++ b/cbam/cbam/page/financial_exposure_forecast/financial_exposure_forecast.py
@@ -97,18 +97,26 @@ def fetch_cbam_report_rows(cbam_reports, from_year, to_year):
                     fields=["price_year", "price", "price_date"],
                     order_by="price_date desc"
                 )
-                if ets_prices:
-                    latest_ets = ets_prices[0]
-                    year = int(latest_ets.price_year)
-                    # Use quarter_year for filtering instead of ETS price year to get actual report data
-                    report_year = quarter_year
-
-                    if (from_year and report_year < from_year) or (to_year and report_year > to_year):
-                        continue
-
-                    ets_price = extract_numeric_value(latest_ets.price)
-                else:
+                if not ets_prices:
+                    # Fallback to latest available ETS price if year-specific price is missing
+                    ets_prices = frappe.get_all(
+                        "ETS Carbon Price",
+                        fields=["price_year", "price", "price_date"],
+                        order_by="price_date desc",
+                        limit=1
+                    )
+                if not ets_prices:
                     continue
+
+                latest_ets = ets_prices[0]
+                year = int(latest_ets.price_year)
+                # Use quarter_year for filtering instead of ETS price year to get actual report data
+                report_year = quarter_year
+
+                if (from_year and report_year < from_year) or (to_year and report_year > to_year):
+                    continue
+
+                ets_price = extract_numeric_value(latest_ets.price)
 
                 # Use quarter_year (report year) for all lookups to ensure consistency
                 report_year = quarter_year
@@ -474,6 +482,9 @@ def get_cbam_report_data(cbam_reports=None, start=0, page_length=50, year=None, 
         else:
             max_future_year = current_year  # fallback: no future projection if no ETS price
 
+        # Cap future projection range to avoid overly long x-axis
+        max_report_year = max(years_with_reports) if years_with_reports else current_year
+        max_future_year = min(max_future_year, max_report_year + 1)
         future_years = [year for year in range(current_year + 1, max_future_year + 1) if year not in years_with_reports]
         future_rows = duplicate_future_year_rows(base_rows, future_years)
 

--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
@@ -398,8 +398,8 @@ def set_conditions(declarants, filters, where_clauses, where_clauses_eg):
         where_clauses.append(f"(g.internal_customs_import_number IN ({reporting_period_list}))")
         where_clauses_eg.append(f"(eg.reporting_period IN ({reporting_period_list}))")
 
-    # Only fetch Good records with status = 'Data Submitted' OR 'Data Assigned'
-    where_clauses.append("g.status IN ('Data Submitted', 'Data Assigned')")
+    # Include all internal Goods except Cancelled
+    where_clauses.append("g.status != 'Cancelled'")
 
     where_sql = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
     where_sql_eg = "WHERE " + " AND ".join(where_clauses_eg) if where_clauses_eg else ""


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/692
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/691

**Summary:**

Allow all internal Goods (except Cancelled) in Various Cost Comparisons and restore Financial Exposure data by falling back to the latest ETS price while capping future years.