### PR TITLE
gallehr/cbam#685: simplify CBAM benchmarks

### DIFF
--- a/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.json
+++ b/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.json
@@ -11,8 +11,6 @@
   "cn_code",
   "reporting_period",
   "column_break_zmxu",
-  "valid_from_year",
-  "valid_to_year",
   "benchmark_values_section",
   "benchmark_values"
  ],
@@ -42,27 +40,10 @@
    "options": "Reporting Period"
   },
   {
-   "fieldname": "valid_from_year",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Valid From Year",
-   "options": "Year",
-   "reqd": 1
-  },
-  {
-   "fieldname": "valid_to_year",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Valid To Year",
-   "options": "Year",
-   "description": "Leave empty for open-ended validity"
-  },
-  {
    "fieldname": "benchmark_values_section",
    "fieldtype": "Section Break",
-   "label": "Benchmark Values"
+   "label": "Benchmark Values",
+   "description": "(1) and (2) indicate time bound values. (1)…Value is to be used for production years 2026-27 (2)… Value is to be used for production years 2028-30. If no time bound values available, system will default to column (1) values."
   },
   {
    "fieldname": "benchmark_values",

--- a/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.py
+++ b/cbam/cbam/doctype/cbam_benchmark/cbam_benchmark.py
@@ -7,14 +7,6 @@ from frappe.model.document import Document
 
 class CBAMBenchmark(Document):
 	def validate(self):
-		# Validate date range
-		if self.valid_from_year and self.valid_to_year:
-			from_year = frappe.db.get_value("Year", self.valid_from_year, "year")
-			to_year = frappe.db.get_value("Year", self.valid_to_year, "year")
-			
-			if from_year and to_year and from_year > to_year:
-				frappe.throw("Valid From Year must be less than or equal to Valid To Year")
-		
 		# Validate unique indicators in benchmark_values table
 		indicators = []
 		for row in self.benchmark_values:
@@ -22,36 +14,6 @@ class CBAMBenchmark(Document):
 				if row.cbam_benchmark_indicator in indicators:
 					frappe.throw(f"Duplicate CBAM Benchmark Indicator '{row.cbam_benchmark_indicator}' found in Benchmark Values table")
 				indicators.append(row.cbam_benchmark_indicator)
-		
-		# Validate no overlapping date ranges for same CN code
-		if self.cn_code and self.valid_from_year:
-			from_year = frappe.db.get_value("Year", self.valid_from_year, "year")
-			to_year = frappe.db.get_value("Year", self.valid_to_year, "year") if self.valid_to_year else None
-			
-			existing = frappe.get_all("CBAM Benchmark",
-				filters={"cn_code": self.cn_code, "name": ["!=", self.name]},
-				fields=["name", "valid_from_year", "valid_to_year"]
-			)
-			
-			for existing_bm in existing:
-				existing_from = frappe.db.get_value("Year", existing_bm.valid_from_year, "year") if existing_bm.valid_from_year else None
-				existing_to = frappe.db.get_value("Year", existing_bm.valid_to_year, "year") if existing_bm.valid_to_year else None
-				
-				if self._ranges_overlap(from_year, to_year, existing_from, existing_to):
-					frappe.throw(f"Date range overlaps with existing benchmark {existing_bm.name}")
-	
-	def _ranges_overlap(self, from1, to1, from2, to2):
-		"""Check if two date ranges overlap"""
-		# If either range is None (open-ended), they overlap if they start before the other ends
-		if to1 is None and to2 is None:
-			return True  # Both open-ended, they overlap
-		if to1 is None:
-			return from1 <= to2  # Range 1 is open-ended
-		if to2 is None:
-			return from2 <= to1  # Range 2 is open-ended
-		
-		# Both have end dates, check overlap
-		return from1 <= to2 and from2 <= to1
 	
 	def on_update(self):
 		"""Update all affected goods when benchmark changes"""

--- a/cbam/cbam/doctype/cbam_benchmark_value/cbam_benchmark_value.json
+++ b/cbam/cbam/doctype/cbam_benchmark_value/cbam_benchmark_value.json
@@ -6,7 +6,8 @@
  "engine": "InnoDB",
  "field_order": [
   "cbam_benchmark_indicator",
-  "emission_benchmark"
+  "emission_benchmark",
+  "emission_benchmark_2"
  ],
  "fields": [
   {
@@ -21,9 +22,16 @@
    "fieldname": "emission_benchmark",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Emission Benchmark [tCO2/tproduct]",
+   "label": "Emission Benchmark [tCO2/tproduct] (1)",
    "non_negative": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "emission_benchmark_2",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Emission Benchmark [tCO2/tproduct] (2)",
+   "non_negative": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/cbam/utils/benchmark.py
+++ b/cbam/utils/benchmark.py
@@ -419,32 +419,33 @@ def get_cbam_benchmark(cn_code, indicator, year):
 	# Get CN code hierarchy for fallback lookup
 	cn_code_hierarchy = get_cn_code_hierarchy(cn_code)
 
+	# Decide which column to use based on reporting year
+	# (1) -> years 2026-27, (2) -> years 2028-30, fallback to (1)
+	benchmark_column = "emission_benchmark"
+	benchmark_alt_column = "emission_benchmark_2"
+	use_alt = year_value is not None and year_value >= 2028
+
 	# Try each CN code in hierarchy (most specific first)
 	for cn_code_to_try in cn_code_hierarchy:
-		# Find CBAM Benchmark with valid date range
+		# Find CBAM Benchmark for CN code (single record per CN code)
 		cbam_docs = frappe.get_all("CBAM Benchmark",
 			filters={"cn_code": cn_code_to_try},
-			fields=["name", "valid_from_year", "valid_to_year"]
+			fields=["name"]
 		)
 
 		for cbam_doc in cbam_docs:
-			from_year = frappe.db.get_value("Year", cbam_doc.valid_from_year, "year") if cbam_doc.valid_from_year else None
-			to_year = frappe.db.get_value("Year", cbam_doc.valid_to_year, "year") if cbam_doc.valid_to_year else None
-
-			# Check if year is in range
-			if from_year and year_value < from_year:
-				continue
-			if to_year and year_value > to_year:
-				continue
-
-			# Year is in range, get the benchmark document
 			cbam = frappe.get_doc("CBAM Benchmark", cbam_doc.name)
 
 			# Find matching indicator
 			for row in cbam.benchmark_values:
 				if row.cbam_benchmark_indicator == indicator:
+					value_primary = getattr(row, benchmark_column, None)
+					value_alt = getattr(row, benchmark_alt_column, None)
+					selected_value = value_alt if use_alt and value_alt is not None else value_primary
+					if selected_value is None:
+						continue
 					return {
-						"emission_benchmark": flt(row.emission_benchmark),
+						"emission_benchmark": flt(selected_value),
 						"cn_code_used": cn_code_to_try
 					}
 


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/685
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/684


**Summary**

- Remove year range fields from CBAM Benchmark and add a two‑column benchmark value model.
- Use column (1) for 2026–27, column (2) for 2028+ with fallback to column (1).
- Add explainer text in the Benchmark Values section and keep indicator uniqueness validation.