### PR TITLE
gallehr/cbam#686: updated Benchmark Selection

### DIFF
--- a/cbam/cbam/doctype/good/good.py
+++ b/cbam/cbam/doctype/good/good.py
@@ -25,9 +25,9 @@ class Good(Document):
 			self.supplier_number, self.supplier_name = frappe.db.get_values("Operating Company", self.operating_company, ['supplier_number', 'supplier_name'])[0]
 
 		self.update_name()
+		self.calculate_default_emission_values()
 		self.calculate_benchmark()
 		self.update_rejection_flags()
-		self.calculate_default_emission_values()
 
 	def update_name(self):
 		for row in self.split_details:
@@ -79,10 +79,12 @@ class Good(Document):
 		# Calculate benchmark if CN code and country are available
 		if self.cn_code and self.country_of_origin:
 			try:
+				indicator_override = self._get_selected_benchmark_indicator()
 				result = calculate_country_specific_benchmark(
 					self.cn_code,
 					self.country_of_origin,
-					self.hand_over_date
+					self.hand_over_date,
+					indicator_override=indicator_override
 				)
 
 				self.country_specific_default_cbam_benchmark = result.get("benchmark_value")
@@ -117,6 +119,13 @@ class Good(Document):
 					"country_of_origin": not bool(self.country_of_origin)
 				}
 			})
+
+	def _get_selected_benchmark_indicator(self):
+		"""Use applicable product's production route for benchmark selection."""
+		for row in self.country_specific_default_emission_values or []:
+			if row.applicable_product and row.production_route_cbam_benchmark_indicator:
+				return row.production_route_cbam_benchmark_indicator
+		return None
 
 	def calculate_default_emission_values(self):
 		"""Populate default emission values from Country Default Values"""

--- a/cbam/utils/benchmark.py
+++ b/cbam/utils/benchmark.py
@@ -7,7 +7,7 @@ from frappe.utils import flt, today, getdate
 
 
 @frappe.whitelist()
-def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
+def calculate_country_specific_benchmark(cn_code, country, reference_date=None, indicator_override=None):
 	"""
 	Calculate country-specific CBAM benchmark with multi-tier fallback
 
@@ -26,13 +26,13 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 	"""
 	warnings = []
 	details = {
-		"cn_code": cn_code,
-		"country": country,
-		"indicator_used": None,
-		"factor_used": None,
-		"base_value": None,
-		"source": None
-	}
+			"cn_code": cn_code,
+			"country": country,
+			"indicator_used": None,
+			"factor_used": None,
+			"base_value": None,
+			"source": None
+		}
 
 	if not cn_code or not country:
 		return {
@@ -63,39 +63,43 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 	details["reference_year"] = reference_year
 
 	try:
-		# Step 1: Get Country Default Values
-		cdb = get_country_default_benchmark(country, cn_code)
+		indicator = None
+		if indicator_override:
+			indicator = indicator_override
+			details["source"] = "selected_in_good"
+		else:
+			# Step 1: Get Country Default Values
+			cdb = get_country_default_benchmark(country, cn_code)
 
-		if not cdb:
-			# Fallback: Try global default
-			cdb = get_global_default_benchmark(cn_code)
 			if not cdb:
-				warnings.append(f"No Country Default for {country} / CN {cn_code}")
-				warnings.append(f"No Global Default for CN {cn_code}")
+				# Fallback: Try global default
+				cdb = get_global_default_benchmark(cn_code)
+				if not cdb:
+					warnings.append(f"No Country Default for {country} / CN {cn_code}")
+					warnings.append(f"No Global Default for CN {cn_code}")
+					return {
+						"benchmark_value": None,
+						"status": "Missing Data",
+						"details": details,
+						"warnings": warnings
+					}
+				details["source"] = "global_default"
+			else:
+				details["source"] = "country_specific"
+
+			indicator = cdb.get("cbam_benchmark_indicator")
+
+			if not indicator:
+				warnings.append("Indicator missing in Country Default Values")
 				return {
 					"benchmark_value": None,
 					"status": "Missing Data",
 					"details": details,
 					"warnings": warnings
 				}
-			details["source"] = "global_default"
-		else:
-			details["source"] = "country_specific"
-
-		indicator = cdb.get("cbam_benchmark_indicator")
-		factor = 1.0
 
 		details["indicator_used"] = indicator
-		details["factor_used"] = factor
-
-		if not indicator:
-			warnings.append("Indicator missing in Country Default Values")
-			return {
-				"benchmark_value": None,
-				"status": "Missing Data",
-				"details": details,
-				"warnings": warnings
-			}
+		details["factor_used"] = None
 
 		# Step 2: Get CBAM Benchmark
 		cbam_benchmark = get_cbam_benchmark(cn_code, indicator, reference_year)
@@ -122,8 +126,8 @@ def calculate_country_specific_benchmark(cn_code, country, reference_date=None):
 				"warnings": warnings
 			}
 
-		# Step 3: Calculate
-		result = flt(base_value) * flt(factor)
+		# Step 3: Use benchmark value directly (no multiplication factor)
+		result = flt(base_value)
 		details["calculated_value"] = result
 
 		return {


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/686
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/684

## Summary
- Benchmark selection in Good now follows the production route chosen in the Default Emission Values table (Applicable Product).
- Benchmark calculation uses the raw benchmark value (multiplication factor removed).
- Fixed indentation error in `calculate_country_specific_benchmark`.

## What Changed
### Good benchmark selection
- The Good document now derives the CBAM Benchmark indicator from the selected Applicable Product row.
- If no Applicable Product is selected, it falls back to the existing Country Default Values selection logic.

### Benchmark calculation
- `calculate_country_specific_benchmark` no longer applies a multiplication factor.
- Calculation details still capture the indicator used and source.

### Bug fix
- Fixed an unexpected indentation error around the `details` dict in `cbam/utils/benchmark.py`.

## Files Updated
- `cbam/cbam/doctype/good/good.py`
- `cbam/utils/benchmark.py`