### PR TITLE
updated Additional, Supplier Specific Benchmark

### DIFF
--- a/cbam/cbam/doctype/external_good/external_good.js
+++ b/cbam/cbam/doctype/external_good/external_good.js
@@ -106,6 +106,21 @@ frappe.ui.form.on("External Good Default Emission Value", {
   }
 });
 
+frappe.ui.form.on("Supplier Specific CBAM Benchmark Value", {
+  applicable_product(frm, cdt, cdn) {
+    const row = locals[cdt][cdn];
+    if (!row.applicable_product) {
+      return;
+    }
+    (frm.doc.supplier_specific_benchmark_values || []).forEach(other => {
+      if (other.name !== row.name && other.applicable_product) {
+        other.applicable_product = 0;
+      }
+    });
+    frm.refresh_field("supplier_specific_benchmark_values");
+  }
+});
+
 function calculate_quantity(frm) {
   if (frm.doc.raw_mass && frm.doc.mass_per_article) {
     frm.set_value('quantity_of_articles', frm.doc.raw_mass / frm.doc.mass_per_article);

--- a/cbam/cbam/doctype/external_good/external_good.json
+++ b/cbam/cbam/doctype/external_good/external_good.json
@@ -41,6 +41,9 @@
   "benchmark_last_calculated_at",
   "use_benchmark_override",
   "benchmark_manual_override",
+  "supplier_specific_default_cbam_benchmark_section",
+  "supplier_specific_default_cbam_benchmark",
+  "supplier_specific_benchmark_values",
   "country_specific_default_emission_values_section",
   "select_applicable_product_for_cn_code",
   "country_specific_default_emission_values"
@@ -253,6 +256,24 @@
    "fieldname": "benchmark_manual_override",
    "fieldtype": "Float",
    "label": "Manual Benchmark Override"
+  },
+  {
+   "fieldname": "supplier_specific_default_cbam_benchmark_section",
+   "fieldtype": "Section Break",
+   "label": "Supplier Specific Default CBAM Benchmark"
+  },
+  {
+   "description": "Supplier-specific benchmark selection based on CN Code and selected production route",
+   "fieldname": "supplier_specific_default_cbam_benchmark",
+   "fieldtype": "Float",
+   "label": "Supplier Specific Default CBAM Benchmark",
+   "read_only": 1
+  },
+  {
+   "fieldname": "supplier_specific_benchmark_values",
+   "fieldtype": "Table",
+   "label": "Supplier Specific Benchmark Values",
+   "options": "Supplier Specific CBAM Benchmark Value"
   },
   {
    "fieldname": "country_specific_default_emission_values_section",

--- a/cbam/cbam/doctype/external_good/external_good.py
+++ b/cbam/cbam/doctype/external_good/external_good.py
@@ -4,14 +4,24 @@
 import json
 import frappe
 from frappe.model.document import Document
-from cbam.utils.benchmark import calculate_country_specific_benchmark, get_country_default_emission_values
+from cbam.utils.benchmark import (
+	calculate_country_specific_benchmark,
+	get_cbam_benchmark,
+	get_cbam_benchmark_rows,
+	get_country_default_benchmark,
+	get_global_default_benchmark,
+	get_country_default_emission_values,
+	resolve_report_year,
+)
 
 
 class ExternalGood(Document):
 	def validate(self):
 		self.set_year_from_report()
-		self.calculate_benchmark()
 		self.calculate_default_emission_values()
+		self.calculate_supplier_specific_benchmark_values()
+		self.calculate_benchmark()
+		self.calculate_supplier_specific_benchmark()
 
 	def set_year_from_report(self):
 		"""Set year field from CBAM Report's from_date/to_date if not already set"""
@@ -154,6 +164,84 @@ class ExternalGood(Document):
 
 		return
 
+	def calculate_supplier_specific_benchmark_values(self):
+		"""Populate supplier-specific benchmark values from CBAM Benchmark."""
+		if not self.cn_code:
+			self.supplier_specific_benchmark_values = []
+			return
+
+		should_refresh = self.is_new() or self.has_value_changed("cn_code") or not self.supplier_specific_benchmark_values
+		selected_indicator = None
+		for row in self.supplier_specific_benchmark_values or []:
+			if row.applicable_product and row.cbam_benchmark_indicator:
+				selected_indicator = row.cbam_benchmark_indicator
+				break
+		if not selected_indicator:
+			for row in self.country_specific_default_emission_values or []:
+				if row.applicable_product and row.production_route_cbam_benchmark_indicator:
+					selected_indicator = row.production_route_cbam_benchmark_indicator
+					break
+
+		if should_refresh:
+			rows, _cn_code_used = get_cbam_benchmark_rows(self.cn_code)
+			self.supplier_specific_benchmark_values = []
+			for row in rows:
+				child = self.append("supplier_specific_benchmark_values", {
+					"cbam_benchmark_indicator": row.get("cbam_benchmark_indicator"),
+					"emission_benchmark": row.get("emission_benchmark"),
+					"emission_benchmark_2": row.get("emission_benchmark_2"),
+				})
+				if selected_indicator and child.cbam_benchmark_indicator == selected_indicator:
+					child.applicable_product = 1
+
+		self._sync_supplier_specific_benchmark_selection_status()
+
+	def _sync_supplier_specific_benchmark_selection_status(self):
+		applicable_rows = [row for row in self.supplier_specific_benchmark_values or [] if row.applicable_product]
+		if len(applicable_rows) > 1:
+			frappe.throw("Only one Supplier Specific Benchmark can be selected.")
+
+	def _get_supplier_specific_indicator(self):
+		for row in self.supplier_specific_benchmark_values or []:
+			if row.applicable_product and row.cbam_benchmark_indicator:
+				return row.cbam_benchmark_indicator
+		return None
+
+	def _get_reporting_year(self):
+		if self.year:
+			return resolve_report_year(self.year)
+		if self.reporting_period:
+			customs_year = frappe.db.get_value("Customs Import", self.reporting_period, "year")
+			return resolve_report_year(customs_year)
+		return None
+
+	def calculate_supplier_specific_benchmark(self):
+		"""Calculate supplier-specific CBAM benchmark value."""
+		if not self.cn_code:
+			self.supplier_specific_default_cbam_benchmark = None
+			return
+
+		indicator = self._get_supplier_specific_indicator()
+		if not indicator:
+			for row in self.country_specific_default_emission_values or []:
+				if row.applicable_product and row.production_route_cbam_benchmark_indicator:
+					indicator = row.production_route_cbam_benchmark_indicator
+					break
+
+		if not indicator and self.installation_country:
+			cdb = get_country_default_benchmark(self.installation_country, self.cn_code)
+			if not cdb:
+				cdb = get_global_default_benchmark(self.cn_code)
+			indicator = cdb.get("cbam_benchmark_indicator") if cdb else None
+
+		if not indicator:
+			self.supplier_specific_default_cbam_benchmark = None
+			return
+
+		report_year = self._get_reporting_year()
+		result = get_cbam_benchmark(self.cn_code, indicator, report_year)
+		self.supplier_specific_default_cbam_benchmark = result.get("emission_benchmark") if result else None
+
 
 @frappe.whitelist()
 def bulk_create_external_goods(rows, declarant=None, cbam_report=None, reporting_period=None, declarant_acts_as_importer=None, importer=None):
@@ -261,5 +349,7 @@ def get_or_create_year(year_value):
     except Exception as e:
         frappe.log_error(f"Error creating Year {year_value}: {str(e)}", "Year Creation Error")
         return None
+
+
 
 

--- a/cbam/cbam/doctype/good/good.js
+++ b/cbam/cbam/doctype/good/good.js
@@ -293,6 +293,21 @@ frappe.ui.form.on("Good Default Emission Value", {
     }
 });
 
+frappe.ui.form.on("Supplier Specific CBAM Benchmark Value", {
+    applicable_product(frm, cdt, cdn) {
+        const row = locals[cdt][cdn];
+        if (!row.applicable_product) {
+            return;
+        }
+        (frm.doc.supplier_specific_benchmark_values || []).forEach(other => {
+            if (other.name !== row.name && other.applicable_product) {
+                other.applicable_product = 0;
+            }
+        });
+        frm.refresh_field("supplier_specific_benchmark_values");
+    }
+});
+
 frappe.ui.form.on("Good", {
     refresh(frm) {
         show_rejection_banner(frm);

--- a/cbam/cbam/doctype/good/good.json
+++ b/cbam/cbam/doctype/good/good.json
@@ -107,6 +107,9 @@
   "benchmark_last_calculated_at",
   "use_benchmark_override",
   "benchmark_manual_override",
+  "supplier_specific_default_cbam_benchmark_section",
+  "supplier_specific_default_cbam_benchmark",
+  "supplier_specific_benchmark_values",
   "country_specific_default_emission_values_section",
   "select_applicable_product_for_cn_code",
   "country_specific_default_emission_values"
@@ -685,6 +688,24 @@
    "fieldname": "benchmark_manual_override",
    "fieldtype": "Float",
    "label": "Manual Benchmark Override"
+  },
+  {
+   "fieldname": "supplier_specific_default_cbam_benchmark_section",
+   "fieldtype": "Section Break",
+   "label": "Supplier Specific Default CBAM Benchmark"
+  },
+  {
+   "description": "Supplier-specific benchmark selection based on CN Code and selected production route",
+   "fieldname": "supplier_specific_default_cbam_benchmark",
+   "fieldtype": "Float",
+   "label": "Supplier Specific Default CBAM Benchmark",
+   "read_only": 1
+  },
+  {
+   "fieldname": "supplier_specific_benchmark_values",
+   "fieldtype": "Table",
+   "label": "Supplier Specific Benchmark Values",
+   "options": "Supplier Specific CBAM Benchmark Value"
   },
   {
    "fieldname": "country_specific_default_emission_values_section",

--- a/cbam/cbam/doctype/good/good.py
+++ b/cbam/cbam/doctype/good/good.py
@@ -6,7 +6,15 @@ from frappe.model.document import Document
 from cbam.send_email.create_email import create_email
 from cbam.send_email.create_new_supplier_user import create_new_supplier_user
 from frappe.model.naming import getseries
-from cbam.utils.benchmark import calculate_country_specific_benchmark, get_country_default_emission_values
+from cbam.utils.benchmark import (
+	calculate_country_specific_benchmark,
+	get_cbam_benchmark,
+	get_cbam_benchmark_rows,
+	get_country_default_benchmark,
+	get_global_default_benchmark,
+	get_country_default_emission_values,
+	resolve_report_year,
+)
 
 
 class Good(Document):
@@ -26,7 +34,9 @@ class Good(Document):
 
 		self.update_name()
 		self.calculate_default_emission_values()
+		self.calculate_supplier_specific_benchmark_values()
 		self.calculate_benchmark()
+		self.calculate_supplier_specific_benchmark()
 		self.update_rejection_flags()
 
 	def update_name(self):
@@ -126,6 +136,73 @@ class Good(Document):
 			if row.applicable_product and row.production_route_cbam_benchmark_indicator:
 				return row.production_route_cbam_benchmark_indicator
 		return None
+
+	def calculate_supplier_specific_benchmark_values(self):
+		"""Populate supplier-specific benchmark values from CBAM Benchmark."""
+		if not self.cn_code:
+			self.supplier_specific_benchmark_values = []
+			return
+
+		should_refresh = self.is_new() or self.has_value_changed("cn_code") or not self.supplier_specific_benchmark_values
+		selected_indicator = None
+		for row in self.supplier_specific_benchmark_values or []:
+			if row.applicable_product and row.cbam_benchmark_indicator:
+				selected_indicator = row.cbam_benchmark_indicator
+				break
+		if not selected_indicator:
+			selected_indicator = self._get_selected_benchmark_indicator()
+
+		if should_refresh:
+			rows, _cn_code_used = get_cbam_benchmark_rows(self.cn_code)
+			self.supplier_specific_benchmark_values = []
+			for row in rows:
+				child = self.append("supplier_specific_benchmark_values", {
+					"cbam_benchmark_indicator": row.get("cbam_benchmark_indicator"),
+					"emission_benchmark": row.get("emission_benchmark"),
+					"emission_benchmark_2": row.get("emission_benchmark_2"),
+				})
+				if selected_indicator and child.cbam_benchmark_indicator == selected_indicator:
+					child.applicable_product = 1
+
+		self._sync_supplier_specific_benchmark_selection_status()
+
+	def _sync_supplier_specific_benchmark_selection_status(self):
+		applicable_rows = [row for row in self.supplier_specific_benchmark_values or [] if row.applicable_product]
+		if len(applicable_rows) > 1:
+			frappe.throw("Only one Supplier Specific Benchmark can be selected.")
+
+	def _get_supplier_specific_indicator(self):
+		for row in self.supplier_specific_benchmark_values or []:
+			if row.applicable_product and row.cbam_benchmark_indicator:
+				return row.cbam_benchmark_indicator
+		return None
+
+	def _get_reporting_year(self):
+		if self.internal_customs_import_number:
+			customs_year = frappe.db.get_value("Customs Import", self.internal_customs_import_number, "year")
+			return resolve_report_year(customs_year)
+		return None
+
+	def calculate_supplier_specific_benchmark(self):
+		"""Calculate supplier-specific CBAM benchmark value."""
+		if not self.cn_code:
+			self.supplier_specific_default_cbam_benchmark = None
+			return
+
+		indicator = self._get_supplier_specific_indicator() or self._get_selected_benchmark_indicator()
+		if not indicator and self.country_of_origin:
+			cdb = get_country_default_benchmark(self.country_of_origin, self.cn_code)
+			if not cdb:
+				cdb = get_global_default_benchmark(self.cn_code)
+			indicator = cdb.get("cbam_benchmark_indicator") if cdb else None
+
+		if not indicator:
+			self.supplier_specific_default_cbam_benchmark = None
+			return
+
+		report_year = self._get_reporting_year() or self.hand_over_date
+		result = get_cbam_benchmark(self.cn_code, indicator, report_year)
+		self.supplier_specific_default_cbam_benchmark = result.get("emission_benchmark") if result else None
 
 	def calculate_default_emission_values(self):
 		"""Populate default emission values from Country Default Values"""
@@ -602,6 +679,8 @@ def send_data_request(goods):
 	for g in goods:
 		if g.get('status') == "Draft":
 			frappe.db.set_value("Good", g.get("name"), "status", "Data Requested")
+
+
 
 
 @frappe.whitelist()

--- a/cbam/cbam/doctype/supplier_specific_cbam_benchmark_value/supplier_specific_cbam_benchmark_value.json
+++ b/cbam/cbam/doctype/supplier_specific_cbam_benchmark_value/supplier_specific_cbam_benchmark_value.json
@@ -1,0 +1,58 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-01-21 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "cbam_benchmark_indicator",
+  "emission_benchmark",
+  "emission_benchmark_2",
+  "applicable_product"
+ ],
+ "fields": [
+  {
+   "fieldname": "cbam_benchmark_indicator",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "CBAM Benchmark Indicator",
+   "options": "CBAM Benchmark Indicator",
+   "reqd": 1
+  },
+  {
+   "fieldname": "emission_benchmark",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Emission Benchmark [tCO2/tproduct] (1)",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "emission_benchmark_2",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Emission Benchmark [tCO2/tproduct] (2)",
+   "non_negative": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "applicable_product",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Applicable Benchmark"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-01-21 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "CBAM",
+ "name": "Supplier Specific CBAM Benchmark Value",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/cbam/cbam/doctype/supplier_specific_cbam_benchmark_value/supplier_specific_cbam_benchmark_value.py
+++ b/cbam/cbam/doctype/supplier_specific_cbam_benchmark_value/supplier_specific_cbam_benchmark_value.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, phamos GmbH and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class SupplierSpecificCBAMBenchmarkValue(Document):
+	pass

--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
@@ -39,7 +39,8 @@ def get_columns():
         {"fieldname": "supplier", "fieldtype": "Data", "label": "Supplier", "width": 200},
         {"fieldname": "raw_mass_tonne", "fieldtype": "Data", "label": "Mass [t]", "width": 150},
         {"fieldname": "installation_country", "fieldtype": "Data", "label": "Installation Country", "width": 180},
-        {"fieldname": "cbam_benchmark", "fieldtype": "Data", "label": "CBAM Benchmark [tCO2/t product]", "width": 200},
+        {"fieldname": "cbam_benchmark", "fieldtype": "Data", "label": "CBAM Default Benchmark [tCO2/t product]", "width": 220},
+        {"fieldname": "supplier_specific_benchmark", "fieldtype": "Data", "label": "Supplier Specific Benchmark [tCO2/t product]", "width": 230},
         {"fieldname": "default_emission_factor", "fieldtype": "Data", "label": "Default Emission Value [tCO2/t product]", "width": 220},
         {"fieldname": "default_emission_cost", "fieldtype": "Data", "label": "Default Cost [€]", "width": 180},
         {"fieldname": "real_emission_value", "fieldtype": "Data", "label": "Specific (Direct) Emission Value [tCO2/t product]", "width": 280},
@@ -128,6 +129,18 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
         if result:
             cbam_factor = float(result[0].get('cbam_factor', 0.0) or 0.0)
             ets_carbon_price = float(result[0].get('ets_price', 0.0) or 0.0)
+        # Fallback: if no ETS price for the selected type, use latest price for the year
+        if year and (not ets_carbon_price or ets_carbon_price == 0):
+            fallback_price = frappe.db.sql("""
+                SELECT price
+                FROM `tabETS Carbon Price`
+                WHERE price_year = %(year)s
+                AND price IS NOT NULL
+                ORDER BY price_date DESC, modified DESC
+                LIMIT 1
+            """, {"year": year}, as_dict=True)
+            if fallback_price:
+                ets_carbon_price = float(fallback_price[0].get("price", 0.0) or 0.0)
 
     # Count total rows for pagination
     total_count = get_count(where_sql, where_sql_eg)
@@ -137,11 +150,12 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
         default_emission_expr = "0.0"
         return f"""
             COALESCE(IFNULL({table_alias}.country_specific_default_cbam_benchmark, 0.0), 0.0) AS cbam_benchmark,
+            COALESCE(IFNULL({table_alias}.supplier_specific_default_cbam_benchmark, {table_alias}.country_specific_default_cbam_benchmark), 0.0) AS supplier_specific_benchmark,
             {default_emission_expr} AS default_emission_factor,
             0.0 AS default_emission_cost,
             IFNULL({table_alias}.specific_direct_embedded_emissions,0.0) AS real_emission_value,
             ((
-                IFNULL({table_alias}.specific_direct_embedded_emissions,0.0) - ({cbam_factor} * COALESCE(IFNULL({table_alias}.country_specific_default_cbam_benchmark, 0.0), 0.0))
+                IFNULL({table_alias}.specific_direct_embedded_emissions,0.0) - ({cbam_factor} * COALESCE(IFNULL({table_alias}.supplier_specific_default_cbam_benchmark, {table_alias}.country_specific_default_cbam_benchmark), 0.0))
                 - ((IFNULL({table_alias}.specific_direct_embedded_emissions,0.0) * IFNULL({table_alias}.carbon_price_due, 0.0)) / {ets_carbon_price})
             ) * IFNULL({table_alias}.raw_mass_tonne, 0.0) * {ets_carbon_price}) AS real_emission_cost
         """
@@ -194,6 +208,7 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                     IFNULL(eg.raw_mass_tonne,0.0) AS raw_mass_tonne,
                     eg.installation_country,
                     COALESCE(IFNULL(eg.country_specific_default_cbam_benchmark, 0.0), 0.0) AS cbam_benchmark,
+                    COALESCE(IFNULL(eg.supplier_specific_default_cbam_benchmark, eg.country_specific_default_cbam_benchmark), 0.0) AS supplier_specific_benchmark,
                     0.0 AS default_emission_factor,
                     0.0 AS default_emission_cost,
                     IFNULL(eg.specific_direct_embedded_emissions,0.0) AS real_emission_value,
@@ -212,6 +227,7 @@ def get_data(filters=None, selected_filters=None, start=0, page_length=50):
                     IFNULL(g.raw_mass_tonne,0.0) AS raw_mass_tonne,
                     g.installation_country,
                     COALESCE(IFNULL(g.country_specific_default_cbam_benchmark, 0.0), 0.0) AS cbam_benchmark,
+                    COALESCE(IFNULL(g.supplier_specific_default_cbam_benchmark, g.country_specific_default_cbam_benchmark), 0.0) AS supplier_specific_benchmark,
                     0.0 AS default_emission_factor,
                     0.0 AS default_emission_cost,
                     IFNULL(g.specific_direct_embedded_emissions,0.0) AS real_emission_value,

--- a/cbam/utils/benchmark.py
+++ b/cbam/utils/benchmark.py
@@ -389,6 +389,31 @@ def get_country_default_emission_values(country, cn_code):
 	return [], {"source": source, "cn_code_used": None}
 
 
+def get_cbam_benchmark_rows(cn_code):
+	"""Fetch CBAM Benchmark rows for a CN code (with hierarchy fallback)."""
+	if not cn_code:
+		return [], None
+
+	cn_code_hierarchy = get_cn_code_hierarchy(cn_code)
+	for cn_code_to_try in cn_code_hierarchy:
+		cbam_docs = frappe.get_all("CBAM Benchmark",
+			filters={"cn_code": cn_code_to_try},
+			fields=["name"]
+		)
+		for cbam_doc in cbam_docs:
+			cbam = frappe.get_doc("CBAM Benchmark", cbam_doc.name)
+			rows = []
+			for row in cbam.benchmark_values:
+				rows.append({
+					"cbam_benchmark_indicator": row.cbam_benchmark_indicator,
+					"emission_benchmark": row.emission_benchmark,
+					"emission_benchmark_2": getattr(row, "emission_benchmark_2", None)
+				})
+			if rows:
+				return rows, cn_code_to_try
+	return [], None
+
+
 def get_default_emission_value(country, cn_code, report_year):
 	"""Get a single Default Emission Value when no Good selection exists."""
 	rows, _details = get_country_default_emission_values(country, cn_code)
@@ -676,6 +701,10 @@ def update_affected_goods_by_cn_code(cn_code):
 		# Update immediately for small sets
 		for good in goods:
 			try:
+				good_doc = frappe.get_doc("Good", good.name)
+				good_doc.calculate_supplier_specific_benchmark_values()
+				good_doc.calculate_supplier_specific_benchmark()
+				good_doc.save(ignore_permissions=True)
 				recalculate_good_benchmark(good.name)
 				recalculate_good_default_emission_values(good.name)
 			except Exception as e:
@@ -685,6 +714,10 @@ def update_affected_goods_by_cn_code(cn_code):
 
 		for eg in external_goods:
 			try:
+				eg_doc = frappe.get_doc("External Good", eg.name)
+				eg_doc.calculate_supplier_specific_benchmark_values()
+				eg_doc.calculate_supplier_specific_benchmark()
+				eg_doc.save(ignore_permissions=True)
 				recalculate_external_good_benchmark(eg.name)
 				recalculate_external_good_default_emission_values(eg.name)
 			except Exception as e:
@@ -743,6 +776,10 @@ def update_affected_goods_by_country(country):
 		# Update immediately for small sets
 		for good in goods:
 			try:
+				good_doc = frappe.get_doc("Good", good.name)
+				good_doc.calculate_supplier_specific_benchmark_values()
+				good_doc.calculate_supplier_specific_benchmark()
+				good_doc.save(ignore_permissions=True)
 				recalculate_good_benchmark(good.name)
 				recalculate_good_default_emission_values(good.name)
 			except Exception as e:
@@ -752,6 +789,10 @@ def update_affected_goods_by_country(country):
 
 		for eg in external_goods:
 			try:
+				eg_doc = frappe.get_doc("External Good", eg.name)
+				eg_doc.calculate_supplier_specific_benchmark_values()
+				eg_doc.calculate_supplier_specific_benchmark()
+				eg_doc.save(ignore_permissions=True)
 				recalculate_external_good_benchmark(eg.name)
 				recalculate_external_good_default_emission_values(eg.name)
 			except Exception as e:
@@ -784,6 +825,10 @@ def batch_update_benchmarks_by_cn_code(cn_code):
 
 	for good in goods:
 		try:
+			good_doc = frappe.get_doc("Good", good.name)
+			good_doc.calculate_supplier_specific_benchmark_values()
+			good_doc.calculate_supplier_specific_benchmark()
+			good_doc.save(ignore_permissions=True)
 			result = recalculate_good_benchmark(good.name)
 			recalculate_good_default_emission_values(good.name)
 			if result.get("success"):
@@ -796,6 +841,10 @@ def batch_update_benchmarks_by_cn_code(cn_code):
 
 	for eg in external_goods:
 		try:
+			eg_doc = frappe.get_doc("External Good", eg.name)
+			eg_doc.calculate_supplier_specific_benchmark_values()
+			eg_doc.calculate_supplier_specific_benchmark()
+			eg_doc.save(ignore_permissions=True)
 			result = recalculate_external_good_benchmark(eg.name)
 			recalculate_external_good_default_emission_values(eg.name)
 			if result.get("success"):
@@ -836,6 +885,10 @@ def batch_update_benchmarks_by_country(country):
 
 	for good in goods:
 		try:
+			good_doc = frappe.get_doc("Good", good.name)
+			good_doc.calculate_supplier_specific_benchmark_values()
+			good_doc.calculate_supplier_specific_benchmark()
+			good_doc.save(ignore_permissions=True)
 			result = recalculate_good_benchmark(good.name)
 			recalculate_good_default_emission_values(good.name)
 			if result.get("success"):
@@ -848,6 +901,10 @@ def batch_update_benchmarks_by_country(country):
 
 	for eg in external_goods:
 		try:
+			eg_doc = frappe.get_doc("External Good", eg.name)
+			eg_doc.calculate_supplier_specific_benchmark_values()
+			eg_doc.calculate_supplier_specific_benchmark()
+			eg_doc.save(ignore_permissions=True)
 			result = recalculate_external_good_benchmark(eg.name)
 			recalculate_external_good_default_emission_values(eg.name)
 			if result.get("success"):


### PR DESCRIPTION
Issue: https://git.phamos.eu/gallehr/cbam/-/work_items/688
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/687

## Summary
- Add supplier‑specific CBAM benchmark selection in Good and External Good.
- Use supplier‑specific benchmark for Specific emission cost calculations.
- Keep default benchmark for Default/Standard emission values and costs.
- Add ETS price fallback to avoid zero Default Cost when data exists.

## What Changed
### Supplier Specific Benchmark selection
- New section in Good/External Good: **Supplier Specific Default CBAM Benchmark**.
- Table populated from CBAM Benchmark values for the CN Code.
- Single selection enforced via checkbox.
- If no supplier‑specific selection, fallback uses Applicable Product from Default Emission Values.

### Benchmark calculation
- Supplier‑specific benchmark is stored on Good/External Good using reporting year.
- Default benchmark remains unchanged for Default/Standard emission calculations.

### Financial Dashboard (Various Cost Comparisons)
- Renamed column to **CBAM Default Benchmark [tCO2/t product]**.
- Added **Supplier Specific Benchmark [tCO2/t product]** column.
- Specific emission cost uses supplier‑specific benchmark (fallback to default).
- Added ETS price fallback when type‑specific price is missing.

## Files Updated
- `cbam/cbam/doctype/good/good.py`
- `cbam/cbam/doctype/external_good/external_good.py`
- `cbam/cbam/doctype/good/good.json`
- `cbam/cbam/doctype/external_good/external_good.json`
- `cbam/cbam/doctype/supplier_specific_cbam_benchmark_value/supplier_specific_cbam_benchmark_value.json`
- `cbam/cbam/doctype/supplier_specific_cbam_benchmark_value/supplier_specific_cbam_benchmark_value.py`
- `cbam/cbam/doctype/good/good.js`
- `cbam/cbam/doctype/external_good/external_good.js`
- `cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py`
- `cbam/utils/benchmark.py`

## Validation
- Not run (pytest not available in this environment).

## Test Plan (manual)
1) **Good/External Good UI**
   - Open a Good/External Good with CN Code.
   - Verify “Supplier Specific Default CBAM Benchmark” section appears.
   - Table populates with CBAM Benchmark rows.
2) **Selection**
   - Select one “Applicable Benchmark” row.
   - Ensure only one row remains selected.
3) **Fallback**
   - Clear supplier‑specific selection.
   - Ensure supplier‑specific benchmark matches Applicable Product selection from Default Emission Values.
4) **Year-based selection**
   - Reporting year 2026/27 → column (1)
   - Reporting year 2028+ → column (2), fallback to (1) if empty
5) **Financial Dashboard**
   - Column renamed to “CBAM Default Benchmark …”.
   - New column “Supplier Specific Benchmark …” shows correct value.
   - Specific cost uses supplier‑specific benchmark; default cost uses default benchmark.
6) **Update sync**
   - Update a CBAM Benchmark value and save.
   - Supplier‑specific table in Good/External Good stays in sync after update hooks run.
