### PR TITLE
gallehr/cbam#692: exclude cancelled entries from report

### DIFF
--- a/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
+++ b/cbam/cbam/page/various_cost_comparisons/various_cost_comparisons.py
@@ -414,8 +414,8 @@ def set_conditions(declarants, filters, where_clauses, where_clauses_eg):
         where_clauses.append(f"(g.internal_customs_import_number IN ({reporting_period_list}))")
         where_clauses_eg.append(f"(eg.reporting_period IN ({reporting_period_list}))")
 
-    # Include all internal Goods except Cancelled
-    where_clauses.append("g.status != 'Cancelled'")
+    # Exclude cancelled documents
+    where_clauses.append("g.docstatus != 2")
 
     where_sql = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
     where_sql_eg = "WHERE " + " AND ".join(where_clauses_eg) if where_clauses_eg else ""


### PR DESCRIPTION
Issue - https://git.phamos.eu/gallehr/cbam/-/work_items/692
Parent - https://git.phamos.eu/gallehr/cbam/-/issues/691

Summary:
Exclude cancelled documents from report